### PR TITLE
 Remove double vertical scroll

### DIFF
--- a/client/view/Article/Article.css
+++ b/client/view/Article/Article.css
@@ -9,14 +9,15 @@
 .Article--stats {
   position: fixed;
   top: 0;
-  right: 0;
+  /* Hide scrollbar */
+  right: calc(-1 * (100vw - 100%));
   display: flex;
   flex-direction: column;
   gap: 16px;
   width: 50%;
   height: 100vh;
   max-height: 100vh;
-  overflow: auto;
+  overflow-y: scroll;
   background-color: var(--bg-highlited);
 }
 


### PR DESCRIPTION
Closes #348

I always hide scrollbar without "jumping". While I offer this **temporary** solution, it is already a little better than before.


---

But It seems that we will need to separate these two scroll areas. Or somehow synchronize them.

It's well described here:
https://github.com/browserslist/browsersl.ist/issues/310#issuecomment-1213038094