### PR TITLE
Improve HTTP error handling

### DIFF
--- a/server/handlers/main.js
+++ b/server/handlers/main.js
@@ -14,7 +14,11 @@ export default async function handleMain(req, res) {
   try {
     let { data } = await getFileData(filePath, true)
     sendResponse(res, 200, responseHeaders, data)
-  } catch ({ status, message }) {
-    sendResponseError(res, status, message)
+  } catch (error) {
+    if (error.httpStatus) {
+      sendResponseError(res, error.httpStatus, error.message)
+    } else {
+      sendResponseError(res, 500, 'Internal Server Error')
+    }
   }
 }

--- a/server/handlers/static.js
+++ b/server/handlers/static.js
@@ -29,8 +29,12 @@ export default async function handleStatic(req, res) {
       'Content-Length': size
     }
     sendResponse(res, 200, resHeaders, data)
-  } catch ({ status, message }) {
-    sendResponseError(res, status, message)
+  } catch (error) {
+    if (error.httpStatus) {
+      sendResponseError(res, error.httpStatus, error.message)
+    } else {
+      sendResponseError(res, 500, 'Internal Server Error')
+    }
   }
 }
 


### PR DESCRIPTION
- [x] `getFileData()` code was simplified by moving from `return Promise(cb)` to `async function`
- [x] `getFileData()` could always return non-standard error (outside of internal `try-catch` statement). Now we are ready for it.