### PR TITLE
Refactor npm scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install production dependencies
         run: pnpm install --prod --frozen-lockfile --ignore-scripts
       - name: Build regions
-        run: pnpm -r build:regions
+        run: pnpm prebuild
       - name: Build static files
         run: pnpm build
       - name: Auth Google Cloud

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install production dependencies
         run: pnpm install --prod --frozen-lockfile --ignore-scripts
       - name: Build regions
-        run: pnpm -r build:regions
+        run: pnpm prebuild
       - name: Build static files
         run: pnpm build
       - name: Auth Google Cloud

--- a/client/package.json
+++ b/client/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "start": "vite build --watch",
     "build": "vite build -m production",
-    "build:regions": "node ./scripts/build-regions.js",
-    "test": "pnpm build && size-limit",
-    "postinstall": "pnpm build:regions"
+    "prebuild": "pnpm prebuild:regions",
+    "prebuild:regions": "node ./scripts/build-regions.js",
+    "test:run": "pnpm prebuild && pnpm build && size-limit",
+    "postinstall": "pnpm build:regions",
+    "test": "pnpm test:run"
   },
   "dependencies": {
     "@csstools/postcss-oklab-function": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   },
   "scripts": {
     "start": "pnpm -r start",
+    "prebuild": "pnpm -r prebuild",
     "build": "pnpm -r build",
     "lint": "eslint . && stylelint **/*.css",
-    "test": "pnpm audit --prod && pnpm lint && pnpm -r test"
+    "test:run": "pnpm audit --prod && pnpm lint",
+    "test": "pnpm -r --include-workspace-root test:run"
   },
   "dependencies": {
     "ssdeploy": "^0.9.1"

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "start": "node index.js",
-    "test": "pnpm -r build && node --test test/*.test.js"
+    "test:run": "pnpm -r build && node --test test/*.test.js",
+    "test": "pnpm test:run"
   },
   "dependencies": {
     "browserslist": "^4.21.3",


### PR DESCRIPTION
- [x] Move `test` to `test:run` to run all 3 tests in parallel (core & server & client) with nice UI. CI will be faster.
- [x] Rename `build:regions` to `prebuild`