### PR TITLE
Set image size to reduce CLS

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -19,23 +19,23 @@
   <article class="Article Article--intro">
     <div class="Article--intro__header">
       <h1 class="Article__h1">
-        <img src="./view/Article/browserlist_logo.svg" alt="">
+        <img class="Article__logo" src="./view/Article/browserlist_logo.svg" alt="">
         Browserslist
       </h1>
       <a class="Badge" href="https://github.com/browserslist/browserslist">
-        <img src="./view/Badge/github_logo.svg" alt="Count of github stars" class="Badge__githubLogo"> 10.5k
+        <img src="./view/Badge/github_logo.svg" alt="Count of github stars" class="Badge__logo"> 10.5k
       </a>
       <a class="Badge" href="https://twitter.com/Browserslist">
-        <img src="./view/Badge/twitter_logo.svg" alt="Count of twitter followers"> 4k
+        <img src="./view/Badge/twitter_logo.svg" alt="Count of twitter followers" class="Badge__logo"> 4k
       </a>
     </div>
     <p class="Article--intro__about">Shared browser and platform compatibility config for popular JavaScript tools,
       including Autoprefixer, Babel, ESLint, PostCSS, and Webpack</p>
     <p class="Article--intro__supported">
       Supported by
-      <img src="./view/Article/evil_maritians_logo.svg" alt="">
+      <img class="Article--intro__martians" src="./view/Article/evil_maritians_logo.svg" alt="">
       <a href="https://evilmartians.com/" class="Link" target="_blank">Evil Martians</a> and
-      <img src="./view/Article/cube_logo.svg" alt="">
+      <img class="Article--intro__cube" src="./view/Article/cube_logo.svg" alt="">
       <a href="https://cube.dev/" class="Link" target="_blank">Cube</a>
     </p>
   </article>

--- a/client/view/Article/Article.css
+++ b/client/view/Article/Article.css
@@ -9,6 +9,7 @@
 .Article--stats {
   position: fixed;
   top: 0;
+
   /* Hide scrollbar */
   right: calc(-1 * (100vw - 100%));
   display: flex;
@@ -42,6 +43,11 @@
   margin: 0;
 }
 
+.Article__logo {
+  width: 32px;
+  height: 32px;
+}
+
 .Article__h2 {
   margin-top: 32px;
   font-size: 22px;
@@ -62,9 +68,18 @@
   letter-spacing: 0.02em;
 }
 
-.Article--intro__supported img {
+.Article--intro__martians,
+.Article--intro__cube {
   height: 16px;
   vertical-align: middle;
+}
+
+.Article--intro__martians {
+  width: 23px;
+}
+
+.Article--intro__cube {
+  width: 17px;
 }
 
 .Article--intro__header {

--- a/client/view/Badge/Badge.css
+++ b/client/view/Badge/Badge.css
@@ -12,6 +12,11 @@
   border-radius: 4px;
 }
 
+.Badge__logo {
+  width: 20px;
+  height: 20px;
+}
+
 @media (prefers-color-scheme: dark) {
   .Badge__githubLogo {
     filter: invert(1);

--- a/client/view/BrowserStats/BrowsersStat.css
+++ b/client/view/BrowserStats/BrowsersStat.css
@@ -74,6 +74,7 @@
   width: 100%;
   object-fit: cover;
   max-width: 380px;
+  aspect-ratio: 380 / 316;
 }
 
 @media (max-width: 740px) {
@@ -162,6 +163,7 @@
 
 .BrowsersStat__icon {
   display: inline;
+  width: 20px;
   height: 20px;
   line-height: 32px;
   vertical-align: middle;
@@ -171,13 +173,13 @@
   display: flex;
   flex-wrap: wrap;
   column-gap: 12px;
-  color: var(--text-secondary);
-  margin-top: auto;
   padding-top: 24px;
+  margin-top: auto;
+  color: var(--text-secondary);
 }
 
 .BrowsersStat__toolsVersionsItem {
+  margin: 0;
   font-size: 14px;
   line-height: 20px;
-  margin: 0;
 }


### PR DESCRIPTION
We don’t have 100% Performance on Lighthouse because of big Cumulative Layout Shift.

It happens because many images do not have explicit size. The browser needs to load an image first and only then it will be able to calculate image size.

This PR set image sizes explicitly.