### PR TITLE
Improve security headers

### DIFF
--- a/server/handlers/main.js
+++ b/server/handlers/main.js
@@ -16,11 +16,6 @@ const responseHeaders = {
   'X-Content-Type-Options': 'nosniff'
 }
 
-if (process.env.NODE_ENV === 'production') {
-  responseHeaders['Strict-Transport-Security'] =
-    'max-age=31536000; includeSubDomains; preload'
-}
-
 export default async function handleMain(req, res) {
   let filePath = new URL('../../client/dist/index.html', import.meta.url)
 

--- a/server/handlers/main.js
+++ b/server/handlers/main.js
@@ -5,7 +5,20 @@ import { sendResponse, sendResponseError } from '../lib/send-response.js'
 
 const responseHeaders = {
   'Content-Type': 'text/html',
-  'Cache-Control': 'public, max-age=300, must-revalidate'
+  'Cache-Control': 'public, max-age=300, must-revalidate',
+  'Content-Security-Policy':
+    `object-src 'none'; ` +
+    `frame-ancestors 'none'; ` +
+    `style-src 'self'; ` +
+    `script-src 'self'`,
+  'X-Frame-Options': 'DENY',
+  'X-XSS-Protection': '1; mode=block',
+  'X-Content-Type-Options': 'nosniff'
+}
+
+if (process.env.NODE_ENV === 'production') {
+  responseHeaders['Strict-Transport-Security'] =
+    'max-age=31536000; includeSubDomains; preload'
 }
 
 export default async function handleMain(req, res) {


### PR DESCRIPTION
Fixes https://github.com/browserslist/browsersl.ist/issues/373

- [x] `Content-Security-Policy` blocks XSS attack
- [x] `X-Frame-Options` blocks adding website inside iframe attack
- [x] `X-Content-Type-Options'` requires sending JS to browser on JS MIME type (to block another way of attack)