### PR TITLE
Fix CSS variables work in old browsers

### DIFF
--- a/client/view/base/colors.css
+++ b/client/view/base/colors.css
@@ -1,23 +1,21 @@
 /* TODO types for this variables */
 
-@media (prefers-color-scheme: light) {
-  :root {
-    --main-bg: oklch(100% 0 0);
-    --bg-highlited: oklch(97% 0.003 286.35);
-    --accent: oklch(44.63% 0.172 258.93);
-    --text-highlited:  oklch(66.37% 0.18 256.56 / 10%);
-    --text-highlited-hover: oklch(57.37% 0.195 257.86 / 14%);
-    --text-primary: oklch(11.264% 0.1 139.088);
-    --text-secondary: oklch(23.5% 0 0 / 65%);
-    --text-underline: oklch(23.5% 0 0 / 40%);
-    --text-underline-hover: oklch(23.5% 0 0);
-    --accent-blue-primary: oklch(43.639% 45.224 280.199);
-    --accent-alternave: oklch(88.4% 0.41 92.834);
-    --separator: oklch(23.5% 0 0 / 12%);
-    --warning: oklch(73% 100 65.45 / 80%);
-    --error: oklch(66% 0.096 30.71);
-    --twitter: oklch(70.35% 0.124 234.85);
-  }
+:root {
+  --main-bg: oklch(100% 0 0);
+  --bg-highlited: oklch(97% 0.003 286.35);
+  --accent: oklch(44.63% 0.172 258.93);
+  --text-highlited: oklch(66.37% 0.18 256.56 / 10%);
+  --text-highlited-hover: oklch(57.37% 0.195 257.86 / 14%);
+  --text-primary: oklch(11.264% 0.1 139.088);
+  --text-secondary: oklch(23.5% 0 0 / 65%);
+  --text-underline: oklch(23.5% 0 0 / 40%);
+  --text-underline-hover: oklch(23.5% 0 0);
+  --accent-blue-primary: oklch(43.639% 45.224 280.199);
+  --accent-alternave: oklch(88.4% 0.41 92.834);
+  --separator: oklch(23.5% 0 0 / 12%);
+  --warning: oklch(73% 100 65.45 / 80%);
+  --error: oklch(66% 0.096 30.71);
+  --twitter: oklch(70.35% 0.124 234.85);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
PostCSS not fallback css-variables from `@media`. Deleted `@media (preferences-color-scheme: light) {` to solve the problem

Closes #404 and (#401 duplicate)