### PR TITLE
Fix CSS componants

### DIFF
--- a/client/index.css
+++ b/client/index.css
@@ -1,2 +1,10 @@
-@import "./view/base/index.css";
-@import "./view/base/colors.css";
+@import "./view/base/base.css";
+@import "./view/BrowserStats/BrowsersStat.css";
+@import "./view/Article/Article.css";
+@import "./view/Form/Form.css";
+@import "./view/Badge/Badge.css";
+@import "./view/QueryLink/QueryLink.css";
+@import "./view/DocSection/DocSection.css";
+@import "./view/Link/Link.css";
+@import "./view/Pre/Pre.css";
+@import "./view/Tweet/Tweet.css";

--- a/client/view/base/base.css
+++ b/client/view/base/base.css
@@ -1,12 +1,4 @@
-@import "../BrowserStats/BrowsersStat.css";
-@import "../Article/Article.css";
-@import "../Form/Form.css";
-@import "../Badge/Badge.css";
-@import "../QueryLink/QueryLink.css";
-@import "../DocSection/DocSection.css";
-@import "../Link/Link.css";
-@import "../Pre/Pre.css";
-@import "../Tweet/Tweet.css";
+@import "./colors.css";
 
 @media (prefers-reduced-motion: reduce) {
   * {


### PR DESCRIPTION
Before, `base` had a special meaning. It imports other components (which it is not use) and do not follow CSS file name convention.

Now it is just a simple component.