### PR TITLE
Allow to write multiline/JSON configs in form

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -45,7 +45,7 @@
     <h2>Check compatible browsers</h2>
     <form data-id="query_form" class="Form">
       <div class="Form__queryTextAreaContainer">
-        <textarea name="query" cols="30" rows="4" required class="Form__queryTextArea" data-id="query_text_area"
+        <textarea name="query" cols="30" rows="5" required class="Form__queryTextArea" data-id="query_text_area"
                   placeholder="Write the Browserslist config here…"></textarea>
         <p class="Form__interactivePlaceholder">Write the Browserslist config here…<br>
           For example

--- a/client/index.html
+++ b/client/index.html
@@ -52,16 +52,6 @@
           <a class="QueryLink"><code>defaults</code></a>,
           <a class="QueryLink"><code>> 0.2% and not dead</code></a>
         </p>
-        <p class="Form__hint Form__hint--progress">Press Enter
-          <span class="Form__enterIcon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none">
-              <path
-                d="M10.71 1.42h-.8a.1.1 0 0 0-.1.1v6.94H3.28V7.5a.1.1 0 0 0-.17-.09l-1.9 1.5a.1.1 0 0 0 0 .17l1.9 1.5a.1.1 0 0 0 .17-.08v-1h6.67c.48 0 .86-.4.86-.87v-7.1a.1.1 0 0 0-.1-.1Z"
-                fill="currentColor" fill-opacity=".4"/>
-            </svg>
-          </span>
-          to submit
-        </p>
         <p class="Form__hint Form__hint--required">Query should be not empty</p>
         <p class="Form__hint Form__hint--error" data-id="error_message">Unknown query</p>
         <p class="Form__loader">Loading…</p>

--- a/client/index.html
+++ b/client/index.html
@@ -121,7 +121,7 @@
       <a href="https://github.com/browserslist/browserslist#browserslist-" class="Link" target="_blank">many other tools</a>
       will find target browsers automatically if you add the following to <b>package.json</b>:
     </p>
-    <a class="QueryLink" data-query="defaults and supports es6-module, maintained node versions"><pre class="Pre">
+    <a class="QueryLink"><pre class="Pre">
       <code>"browserslist": [</code>
       <code>  "defaults and supports es6-module",</code>
       <code>  "maintained node versions"</code>

--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -11,7 +11,7 @@
 .Form__queryTextArea {
   box-sizing: border-box;
   width: 100%;
-  min-height: 120px;
+  min-height: 134px;
   padding: 12px;
   font-family: 'Martian Mono', monospace;
   font-weight: 300;

--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -109,10 +109,6 @@
   opacity: 100%;
 }
 
-.Form:not(.Form--serverError):not(.Form--justSend):not(.Form--loaded) .Form__queryTextArea:focus-visible:valid ~ .Form__hint--progress {
-  opacity: 100%;
-}
-
 .Form--loaded .Form__loader {
   opacity: 100%;
 }

--- a/client/view/Form/form.js
+++ b/client/view/Form/form.js
@@ -6,6 +6,7 @@ import {
   updateToolsVersions,
   showStats
 } from '../BrowserStats/browserStats.js'
+import transformQuery from './transformQuery.js'
 
 const form = document.querySelector('[data-id=query_form]')
 const textarea = document.querySelector('[data-id=query_text_area]')
@@ -129,9 +130,13 @@ function renderError(message) {
 
 async function updateStatsView(query, region) {
   let response
+
   try {
     form.classList.add('Form--loaded')
-    let urlParams = new URLSearchParams({ q: query, region })
+    let urlParams = new URLSearchParams({
+      q: transformQuery(query),
+      region
+    })
     response = await fetch(`/api/browsers?${urlParams}`)
   } catch (error) {
     renderError(`Network error. Check that you are online.`)

--- a/client/view/Form/form.js
+++ b/client/view/Form/form.js
@@ -18,11 +18,10 @@ const errorMessage = document.querySelector('[data-id=error_message]')
 
 form.addEventListener('submit', handleFormSubmit)
 
-textarea.addEventListener('keypress', e => {
-  if (e.key === 'Enter' && !e.shiftKey) {
-    e.preventDefault()
-    submitForm()
-  }
+const submitFormDebounced = debounce(submitForm, 300)
+
+textarea.addEventListener('input', () => {
+  submitFormDebounced()
 })
 
 renderRegionSelectOptions()
@@ -198,4 +197,12 @@ function submitFormWithUrlParams() {
 
   setFormValues({ query, region })
   submitForm()
+}
+
+function debounce(callback, delay) {
+  let timeout
+  return function () {
+    clearTimeout(timeout)
+    timeout = setTimeout(callback, delay)
+  }
 }

--- a/client/view/Form/transformQuery.js
+++ b/client/view/Form/transformQuery.js
@@ -1,0 +1,43 @@
+const JSON_FRAGMENT_REQUIRED_SYMBOLS = [':', '[', ']']
+
+export default function transformQuery(rawQuery) {
+  let query = rawQuery.trim()
+
+  if (hasJSONSymbols(query)) {
+    try {
+      return transfromJSONToQuery(query)
+    } catch {}
+    try {
+      return transfromJSONFragmentToQuery(query)
+    } catch {}
+  }
+
+  if (query.includes('\n')) {
+    return transformMultilineToQuery(query)
+  }
+
+  return query
+}
+
+function transfromJSONToQuery(query) {
+  let data = JSON.parse(query).browserslist
+  return data.join(',')
+}
+
+function transfromJSONFragmentToQuery(query) {
+  return transfromJSONToQuery('{' + query + '}')
+}
+
+function transformMultilineToQuery(query) {
+  // Replace newline to browserslist `or`
+  return query.replace(/\n/, ',')
+}
+
+function hasJSONSymbols(query) {
+  for (let symbol of JSON_FRAGMENT_REQUIRED_SYMBOLS) {
+    if (!query.includes(symbol)) {
+      return false
+    }
+  }
+  return true
+}

--- a/server/handlers/api-browsers.js
+++ b/server/handlers/api-browsers.js
@@ -10,7 +10,7 @@ export default async function handleAPIBrowsers(req, res) {
   let { searchParams: params } = new URL(req.url, `http://${req.headers.host}/`)
 
   let query = params.get('q') || QUERY_DEFAULTS
-  let queryWithoutQuotes = query.replace(/'/g, '')
+  let queryWithoutQuotes = query.replace(/'|"/g, '')
 
   let region = params.get('region') || REGION_GLOBAL
 


### PR DESCRIPTION
- [x] Query transform
   - Multiline
   - JSON
   - JSON Fragment (without `{` and  `}` symbols)
- [x] Increase `<textarea>` height
- [x] Add debounced submit by input in `<textarea>` ~~Update hotkeys.`Enter` for sumbit, `Shift+Enter` for newline.~~ ~~Ctrl+Enter (⌘+Enter) —  _But earlier it was more convenient for me :( It seems better to write that `Use Ctrl+Shift for line wrapping`_~~
- [x] Small impovments in server and content

Closes #388

Closes https://github.com/browserslist/browsersl.ist/issues/387

![image](https://user-images.githubusercontent.com/22644149/185105062-e51b87e6-174a-4608-b3cf-cc2933e3a96d.png)
