### PR TITLE
Improve index.html headers

### DIFF
--- a/server/handlers/main.js
+++ b/server/handlers/main.js
@@ -4,8 +4,8 @@ import getFileData from '../lib/get-file-data.js'
 import { sendResponse, sendResponseError } from '../lib/send-response.js'
 
 const responseHeaders = {
-  'Content-Type': 'text/html',
-  'Cache-Control': 'public, max-age=300, must-revalidate',
+  'Content-Type': 'text/html; charset=utf-8',
+  'Cache-Control': 'public, max-age=300',
   'Content-Security-Policy':
     `object-src 'none'; ` +
     `frame-ancestors 'none'; ` +

--- a/server/handlers/static.js
+++ b/server/handlers/static.js
@@ -6,7 +6,6 @@ import getFileData from '../lib/get-file-data.js'
 const CLIENT_DIR = '../../client'
 const DIST_DIR = '/dist'
 const MIME_TYPES = {
-  '.html': 'text/html',
   '.js': 'text/javascript',
   '.css': 'text/css',
   '.json': 'application/json',


### PR DESCRIPTION
According to [this threat](https://twitter.com/subzey/status/1559841999292882944).

1. Adding `; charset=utf-8` will avoid scaning for `<meta charset>`
2. With `must-revalidate` we disabled CDN caching