### PR TITLE
Fix a broken API response to request with not-latin characters

### DIFF
--- a/server/lib/send-response.js
+++ b/server/lib/send-response.js
@@ -10,7 +10,7 @@ export function sendResponseAPI(res, status, data) {
   res.writeHead(status, {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'text/json',
-    'Content-Length': JSONData.length
+    'Content-Length': new Blob([JSONData]).size
   })
   res.write(JSONData)
   res.end()


### PR DESCRIPTION
Fix bad `Content-Length` header calculating for responses with non-latin symbols

Closes #426