### PR TITLE
Make the query in the URL more readable

### DIFF
--- a/client/view/Form/form.js
+++ b/client/view/Form/form.js
@@ -43,7 +43,7 @@ function handleFormSubmit(e) {
   }
 
   let formData = new FormData(form)
-  let query = formData.get('query')
+  let query = transformQuery(formData.get('query'))
   let region = formData.get('region')
 
   changeUrl(query, region)
@@ -133,7 +133,7 @@ async function updateStatsView(query, region) {
   try {
     form.classList.add('Form--loaded')
     let urlParams = new URLSearchParams({
-      q: transformQuery(query),
+      q: query,
       region
     })
     response = await fetch(`/api/browsers?${urlParams}`)


### PR DESCRIPTION
Transform `rawQuery` to `query` not only for `fetch`, but also for `history.pushState`

![image](https://user-images.githubusercontent.com/22644149/185269852-5cd9b34c-438f-4ab6-a663-901c679b304a.png)
