### PR TITLE
Show a placeholder with a hedgehog when the `<textarea>` is empty

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -52,7 +52,6 @@
           <a class="QueryLink"><code>defaults</code></a>,
           <a class="QueryLink"><code>> 0.2% and not dead</code></a>
         </p>
-        <p class="Form__hint Form__hint--required">Query should be not empty</p>
         <p class="Form__hint Form__hint--error" data-id="error_message">Unknown query</p>
         <p class="Form__loader">Loading…</p>
       </div>

--- a/client/index.html
+++ b/client/index.html
@@ -56,7 +56,7 @@
         <p class="Form__hint Form__hint--error" data-id="error_message">Unknown query</p>
         <p class="Form__loader">Loading…</p>
       </div>
-      <div class="Form__coverage Form__coverage--hidden" data-id="region_coverage">
+      <div class="Form__coverage" data-id="region_coverage" hidden>
         <h2>Audience coverage: <span data-id="region_coverage_counter"></span></h2>
         <label class="Form__coverageSelectLabel">
           Region
@@ -77,7 +77,7 @@
         <p class="BrowsersStat__placeholderText">Add the Browserslist config to display compatible browsers.</p>
       </div>
 
-      <div class="BrowsersStat__stat BrowsersStat__stat--hidden" data-id="browsers_stats">
+      <div class="BrowsersStat__stat" data-id="browsers_stats" hidden>
         <ul class="BrowsersStat__regionCoverageBar" data-id="region_coverage_bar"></ul>
         <div class="BrowsersStat__tableContainer" data-id="browsers_stats_results"></div>
 

--- a/client/view/BrowserStats/BrowsersStat.css
+++ b/client/view/BrowserStats/BrowsersStat.css
@@ -95,18 +95,10 @@
   text-align: center;
 }
 
-.BrowsersStat__placeholder--hidden {
-  display: none;
-}
-
 .BrowsersStat__stat {
   display: flex;
   flex-direction: column;
   min-height: 100%;
-}
-
-.BrowsersStat__stat--hidden {
-  display: none;
 }
 
 .BrowsersStat__table {

--- a/client/view/BrowserStats/browserStats.js
+++ b/client/view/BrowserStats/browserStats.js
@@ -1,6 +1,16 @@
 import wikipediaLinks from '../../data/wikipedia-links.js'
 import * as browsersIcons from '../../data/browsers-logos.js'
 
+const browserStats = document.querySelector('[data-id=browsers_stats]')
+
+const regionCoverage = document.querySelector('[data-id=region_coverage]')
+const regionCoverageCounter = document.querySelector(
+  '[data-id=region_coverage_counter]'
+)
+const palceholder = document.querySelector(
+  '[data-id=browsers_stats_placeholder]'
+)
+
 function formatPercent(percent) {
   let rounded = percent >= 0.1 ? percent.toFixed(1) : 0
 
@@ -8,8 +18,7 @@ function formatPercent(percent) {
 }
 
 export function updateRegionCoverageCounter(coverage) {
-  let element = document.querySelector('[data-id=region_coverage_counter]')
-  element.innerHTML = formatPercent(coverage)
+  regionCoverageCounter.innerHTML = formatPercent(coverage)
 }
 
 export function updateRegionCoverageBar(data) {
@@ -28,14 +37,10 @@ export function updateRegionCoverageBar(data) {
   })
 }
 
-export function showStats() {
-  let statsPlaceholder = document.querySelector(
-    '[data-id=browsers_stats_placeholder]'
-  )
-  let browserStats = document.querySelector('[data-id=browsers_stats]')
-
-  statsPlaceholder.classList.add('BrowsersStat__placeholder--hidden')
-  browserStats.classList.remove('BrowsersStat__stat--hidden')
+export function toggleShowStats(isShown) {
+  regionCoverage.hidden = !isShown
+  browserStats.hidden = !isShown
+  palceholder.hidden = isShown
 }
 
 function createCoverageCell(coverage) {

--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -79,10 +79,6 @@
   opacity: 0%;
 }
 
-.Form__hint--required {
-  color: var(--warning);
-}
-
 .Form__hint--error {
   color: var(--error);
 }
@@ -103,10 +99,6 @@
 
 .Form__queryTextArea:placeholder-shown ~ .Form__interactivePlaceholder a {
   pointer-events: initial;
-}
-
-.Form:not(.Form--serverError):not(.Form--loaded) .Form__queryTextArea:invalid:focus-visible ~ .Form__hint--required {
-  opacity: 100%;
 }
 
 .Form--loaded .Form__loader {
@@ -145,10 +137,6 @@
   gap: 16px 24px;
   align-items: center;
   justify-content: space-between;
-}
-
-.Form__coverage--hidden {
-  display: none;
 }
 
 .Form__coverageSelect {

--- a/client/view/Form/form.js
+++ b/client/view/Form/form.js
@@ -4,13 +4,12 @@ import {
   updateRegionCoverageCounter,
   updateRegionCoverageBar,
   updateToolsVersions,
-  showStats
+  toggleShowStats
 } from '../BrowserStats/browserStats.js'
 import transformQuery from './transformQuery.js'
 
 const form = document.querySelector('[data-id=query_form]')
 const textarea = document.querySelector('[data-id=query_text_area]')
-const regionCoverage = document.querySelector('[data-id=region_coverage]')
 const regionCoverageSelect = document.querySelector(
   '[data-id=region_coverage_select]'
 )
@@ -38,9 +37,6 @@ window.addEventListener('popstate', () => {
 
 function handleFormSubmit(e) {
   e.preventDefault()
-  if (!form.checkValidity()) {
-    return
-  }
 
   let formData = new FormData(form)
   let query = transformQuery(formData.get('query'))
@@ -77,10 +73,6 @@ export function setFormValues({ query, region }) {
 
 export function submitForm() {
   form.dispatchEvent(new Event('submit', { cancelable: true }))
-}
-
-function showCoverageControls() {
-  regionCoverage.classList.remove('Form__coverage--hidden')
 }
 
 function renderRegionSelectOptions() {
@@ -130,6 +122,11 @@ function renderError(message) {
 async function updateStatsView(query, region) {
   let response
 
+  if (query.length === 0) {
+    toggleShowStats(false)
+    return false
+  }
+
   try {
     form.classList.add('Form--loaded')
     let urlParams = new URLSearchParams({
@@ -164,8 +161,7 @@ Report an issue</a> to our repository.`)
 
   let { browsers, coverage, versions } = data
 
-  showCoverageControls()
-  showStats()
+  toggleShowStats(true)
   updateBrowsersStats(browsers)
   updateRegionCoverageCounter(coverage)
   updateRegionCoverageBar(browsers)

--- a/client/view/base/base.css
+++ b/client/view/base/base.css
@@ -30,3 +30,7 @@ code {
   line-height: 22px;
   font-weight: 600;
 }
+
+[hidden] {
+  display: none !important;
+}


### PR DESCRIPTION
Show a placeholder with a hedgehog when the `<textarea>` is empty

**Other changes**
- Remove hint about required non-empty `<textarea>`
- Refactoring. Replace `*--hidden` BEM classes to `[hidden]` attribute

Closes #379

