### PR TITLE
Disable quotes removing from `query` on server

### DIFF
--- a/server/handlers/api-browsers.js
+++ b/server/handlers/api-browsers.js
@@ -10,12 +10,10 @@ export default async function handleAPIBrowsers(req, res) {
   let { searchParams: params } = new URL(req.url, `http://${req.headers.host}/`)
 
   let query = params.get('q') || QUERY_DEFAULTS
-  let queryWithoutQuotes = query.replace(/'|"/g, '')
-
   let region = params.get('region') || REGION_GLOBAL
 
   try {
-    sendResponseAPI(res, 200, await getBrowsers(queryWithoutQuotes, region))
+    sendResponseAPI(res, 200, await getBrowsers(query, region))
   } catch (error) {
     sendResponseAPI(res, 400, { message: error.message })
   }


### PR DESCRIPTION
Previously (v1 site) we cut quotes `'` on the server side.

It seems that now we don't need this logic if we want 1-1 matching queries. This is breaking-change.

![image](https://user-images.githubusercontent.com/22644149/185284599-4ed6e01c-b368-43c9-917c-6cc4fc1fd238.png)
