### PR TITLE
Simplify `getBrowsers()` function

### DIFF
--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -24,15 +24,8 @@ export default async function getBrowsers(query, region) {
       return
     }
 
-    let browsersGroups = {}
-    let browsersGroupsKeys = []
-
+    let browsersNames = {}
     for (let browser of browsersByQuery) {
-      if (browsersGroupsKeys.includes(browser)) {
-        return
-      }
-
-      browsersGroupsKeys.push(browser)
       let [id, version] = browser.split(' ')
       let versionCoverage = null
 
@@ -49,14 +42,14 @@ export default async function getBrowsers(query, region) {
 
       let versionData = { [`${version}`]: roundNumber(versionCoverage) }
 
-      if (!browsersGroups[id]) {
-        browsersGroups[id] = { versions: versionData }
+      if (!browsersNames[id]) {
+        browsersNames[id] = { versions: versionData }
       } else {
-        Object.assign(browsersGroups[id].versions, versionData)
+        Object.assign(browsersNames[id].versions, versionData)
       }
     }
 
-    let browsers = Object.entries(browsersGroups)
+    let browsers = Object.entries(browsersNames)
       .map(([id, { versions }]) => {
         let name
         let coverage

--- a/server/test/browsers.test.js
+++ b/server/test/browsers.test.js
@@ -14,6 +14,15 @@ test('Throws error for wrong browserslist `query`', async () => {
   match(error.message, /Unknown browser query/)
 })
 
+test('Returns multiple browser names and versions by `>1%` query', async () => {
+  let data = await getBrowsers('>1%', 'Global')
+  let browsersNames = data.browsers
+  let browsersVersions = Object.keys(browsersNames[0])
+
+  ok(browsersNames.length > 0)
+  ok(browsersVersions.length > 0)
+})
+
 test('Throws error for wrong Can I Use `region`', async () => {
   let error
   try {


### PR DESCRIPTION
I did a refactoring `getBrowsers()` before fix audience coverage issues in https://github.com/browserslist/browsersl.ist/issues/423

I did it as the same way as in a similar PR https://github.com/browserslist/browsersl.ist/pull/371:
- `getBrowsers()` was simplified by moving from `return Promise(cb)` to `async function`
- `getBrowsers()` could always return non-standard error (outside of internal try-catch statement). Now we are ready for it.

Additional:
- Removed unused loop for check unique browsers versions `getBrowsers()`. [Browserslist ensures that all returnable values are unique](https://github.com/browserslist/browserslist/blob/eb83bb3865cab145e2c72ea73012d502b8a351b5/test/main.test.js#L43) 
- Added simple coverage test for `>1%` query

