### PR TITLE
Return `null` coverage for Node.js and output `—` symbol in stats

### DIFF
--- a/client/view/BrowserStats/browserStats.js
+++ b/client/view/BrowserStats/browserStats.js
@@ -44,7 +44,8 @@ export function toggleShowStats(isShown) {
 }
 
 function createCoverageCell(coverage) {
-  let coveragePercentageHtmlString = cov => formatPercent(cov)
+  let coveragePercentageHtmlString = cov =>
+    cov !== null ? formatPercent(cov) : '—'
   let coveragePercentageCssString = cov => {
     let result = (Math.log(1 + cov) * 100) / Math.log(1 + 100)
     if (result === 0) {

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -20,7 +20,7 @@ export default async function getBrowsers(query, region) {
       : new Error(`Unknown browser query \`${query}\`.`)
   }
 
-  let browsersByQueryCoverage = {}
+  let browsersCoverageByQuery = {}
 
   for (let browser of browsersByQuery) {
     let [id, version] = browser.split(' ')
@@ -37,14 +37,14 @@ export default async function getBrowsers(query, region) {
       )
     }
 
-    if (!browsersByQueryCoverage[id]) {
-      browsersByQueryCoverage[id] = {}
+    if (!browsersCoverageByQuery[id]) {
+      browsersCoverageByQuery[id] = {}
     }
 
-    browsersByQueryCoverage[id][version] = versionCoverage
+    browsersCoverageByQuery[id][version] = versionCoverage
   }
 
-  let browsers = Object.entries(browsersByQueryCoverage)
+  let browsers = Object.entries(browsersCoverageByQuery)
     .map(([id, versions]) => {
       let name
       let coverage

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -20,29 +20,31 @@ export default async function getBrowsers(query, region) {
       : new Error(`Unknown browser query \`${query}\`.`)
   }
 
-  let browsersNames = {}
+  let browsersByQueryCoverage = {}
+
   for (let browser of browsersByQuery) {
     let [id, version] = browser.split(' ')
-    let versionCoverage = null
+    let versionCoverage
 
-    if (id !== 'node') {
+    // The Node.js is not in the Can I Use db
+    if (id === 'node') {
+      versionCoverage = null
+    } else {
       versionCoverage =
         region === REGION_GLOBAL
           ? getGlobalCoverage(id, version)
           : await getRegionCoverage(id, version, region)
     }
 
-    let versionData = { [`${version}`]: roundNumber(versionCoverage) }
-
-    if (!browsersNames[id]) {
-      browsersNames[id] = { versions: versionData }
-    } else {
-      Object.assign(browsersNames[id].versions, versionData)
+    if (!browsersByQueryCoverage[id]) {
+      browsersByQueryCoverage[id] = {}
     }
+
+    browsersByQueryCoverage[id][version] = roundNumber(versionCoverage)
   }
 
-  let browsers = Object.entries(browsersNames)
-    .map(([id, { versions }]) => {
+  let browsers = Object.entries(browsersByQueryCoverage)
+    .map(([id, versions]) => {
       let name
       let coverage
 

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -30,17 +30,18 @@ export default async function getBrowsers(query, region) {
     if (id === 'node') {
       versionCoverage = null
     } else {
-      versionCoverage =
+      versionCoverage = roundNumber(
         region === REGION_GLOBAL
           ? getGlobalCoverage(id, version)
           : await getRegionCoverage(id, version, region)
+      )
     }
 
     if (!browsersByQueryCoverage[id]) {
       browsersByQueryCoverage[id] = {}
     }
 
-    browsersByQueryCoverage[id][version] = roundNumber(versionCoverage)
+    browsersByQueryCoverage[id][version] = versionCoverage
   }
 
   let browsers = Object.entries(browsersByQueryCoverage)


### PR DESCRIPTION
This is an addition to PR https://github.com/browserslist/browsersl.ist/pull/438

I continue to simplify `getBrowsers()` before Issue https://github.com/browserslist/browsersl.ist/issues/423

**Changes**
- Refactor getting versions coverage
  - Rename `browsersNames` → `browsersCoverageByQuery`
  - Simplify temporary object
`{ node: { versions: { '18.5.0': 0 } } }` → `{ node: { '18.5.0': null } }`.
 Before we created an object with `versions` field that was not used, only destructured

- Add output `—` for Node.js versions with `null` coverage

![image](https://user-images.githubusercontent.com/22644149/185594604-f8566e9e-09ca-40fe-b50c-f2079eb96bfa.png)
