### PR TITLE
Improve a11y

### DIFF
--- a/client/index.css
+++ b/client/index.css
@@ -8,3 +8,4 @@
 @import "./view/DocSection/DocSection.css";
 @import "./view/Link/Link.css";
 @import "./view/Pre/Pre.css";
+@import "./view/Skip/Skip.css";

--- a/client/index.html
+++ b/client/index.html
@@ -42,7 +42,7 @@
     </p>
   </article>
 
-  <article class="Article Article--stats" data-id="query_container">
+  <main class="Article Article--stats" data-id="query_container">
     <h2>Check compatible browsers</h2>
     <form data-id="query_form" class="Form">
       <div class="Form__queryTextAreaContainer">
@@ -90,7 +90,7 @@
         </div>
       </div>
     </div>
-  </article>
+  </main>
 
   <article class="Article Article--docs">
     <h2 class="Article__h2">How to get started</h2>

--- a/client/index.html
+++ b/client/index.html
@@ -17,7 +17,7 @@
 </head>
 
 <body>
-  <button class="Skip" data-id="skip">Skip to Browserslist preview form</button>
+  <button class="Skip" data-id="skip">Skip to form</button>
   <article class="Article Article--intro">
     <div class="Article--intro__header">
       <h1 class="Article__h1">

--- a/client/index.html
+++ b/client/index.html
@@ -46,13 +46,12 @@
     <h2>Check compatible browsers</h2>
     <form data-id="query_form" class="Form">
       <div class="Form__queryTextAreaContainer">
-        <textarea name="query" cols="30" rows="5" required class="Form__queryTextArea" data-id="query_text_area"
-                  placeholder="Write the Browserslist config here…"></textarea>
-        <p class="Form__interactivePlaceholder">Write the Browserslist config here…<br>
+        <textarea id="form_query" name="query" cols="30" rows="5" required class="Form__queryTextArea" data-id="query_text_area"></textarea>
+        <label for="form_query" class="Form__interactivePlaceholder">Write the Browserslist config here…<br>
           For example
           <a class="QueryLink"><code>defaults</code></a>,
           <a class="QueryLink"><code>> 0.2% and not dead</code></a>
-        </p>
+        </label>
         <p class="Form__loader">Loading…</p>
         <p class="Form__hint Form__hint--error" data-id="error_message">Unknown query</p>
       </div>

--- a/client/index.html
+++ b/client/index.html
@@ -46,7 +46,7 @@
     <h2>Check compatible browsers</h2>
     <form data-id="query_form" class="Form">
       <div class="Form__queryTextAreaContainer">
-        <textarea id="form_query" name="query" cols="30" rows="5" required class="Form__queryTextArea" data-id="query_text_area"></textarea>
+        <textarea id="form_query" name="query" cols="30" rows="5" required class="Form__queryTextArea" data-id="query_text_area" placeholder="Write the Browserslist config here…"></textarea>
         <label for="form_query" class="Form__interactivePlaceholder">Write the Browserslist config here…<br>
           For example
           <a class="QueryLink"><code>defaults</code></a>,

--- a/client/index.html
+++ b/client/index.html
@@ -53,7 +53,7 @@
           <a class="QueryLink"><code>> 0.2% and not dead</code></a>
         </label>
         <p class="Form__loader">Loading…</p>
-        <p class="Form__hint Form__hint--error" data-id="error_message">Unknown query</p>
+        <div id="form_error" class="Form__hint Form__hint--error" data-id="error_message" role="alert"></div>
       </div>
       <div class="Form__coverage" data-id="region_coverage" hidden>
         <h2>Audience coverage: <span data-id="region_coverage_counter"></span></h2>

--- a/client/index.html
+++ b/client/index.html
@@ -17,6 +17,7 @@
 </head>
 
 <body>
+  <button class="Skip" data-id="skip">Skip to Browserslist preview form</button>
   <article class="Article Article--intro">
     <div class="Article--intro__header">
       <h1 class="Article__h1">

--- a/client/index.html
+++ b/client/index.html
@@ -17,8 +17,8 @@
 </head>
 
 <body>
-  <button class="Skip" data-id="skip">Skip to form</button>
-  <article class="Article Article--intro">
+  <header class="Article Article--intro">
+    <button class="Skip" data-id="skip">Skip to form</button>
     <div class="Article--intro__header">
       <h1 class="Article__h1">
         <img class="Article__logo" src="./view/Article/browserlist_logo.svg" alt="">
@@ -40,7 +40,7 @@
       <img class="Article--intro__cube" src="./view/Article/cube_logo.svg" alt="">
       <a href="https://cube.dev/?ref=eco-browserslist" class="Link" target="_blank">Cube</a>
     </p>
-  </article>
+  </header>
 
   <main class="Article Article--stats" data-id="query_container">
     <h2>Check compatible browsers</h2>

--- a/client/index.js
+++ b/client/index.js
@@ -1,2 +1,3 @@
 import './view/Form/Form.js'
 import './view/QueryLink/QueryLink.js'
+import './view/Skip/Skip.js'

--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -13,15 +13,15 @@
   width: 100%;
   min-height: 134px;
   padding: 12px;
-  font-family: 'Martian Mono', monospace;
-  font-weight: 300;
+  font-family: "Martian Mono", monospace;
   font-size: 14px;
+  font-weight: 300;
   line-height: 22px;
   color: inherit;
+  resize: vertical;
   background-color: var(--main-bg);
   border: none;
   border-radius: 8px;
-  resize: vertical;
 }
 
 .Form__queryTextArea::placeholder {
@@ -39,7 +39,7 @@
   left: 16px;
   max-width: calc(100% - 12px * 2);
   margin: 0;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 500;
   line-height: 1;
   color: var(--text-secondary);
@@ -51,10 +51,6 @@
 
 .Form__loader {
   pointer-events: none;
-}
-
-.Form__hint--hidden {
-  opacity: 0%;
 }
 
 .Form__enterIcon {
@@ -74,7 +70,7 @@
   top: 12px;
   left: 12px;
   margin: 0;
-  font-family: 'Martian Mono', monospace;
+  font-family: "Martian Mono", monospace;
   font-size: 14px;
   line-height: 22px;
   color: var(--text-secondary);
@@ -143,32 +139,32 @@
 }
 
 .Form__coverageSelect {
-  appearance: none;
   display: inline-block;
   width: fit-content;
   max-width: 200px;
-  padding: .2125em 1.25em .25em .5em;
-  font-size: 16px;
-  font-family: inherit;
   height: 28px;
+  padding: 0.2125em 1.25em 0.25em 0.5em;
+  overflow: hidden;
+  font-family: inherit;
+  font-size: 16px;
   line-height: 1.42;
   color: var(--accent);
+  text-overflow: ellipsis;
+  white-space: nowrap;
   background-color: var(--main-bg);
   background-image: url(./select-arrow-light.svg);
   background-repeat: no-repeat;
   background-position: 96% 54%;
   border: none;
   border-radius: 4px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  appearance: none;
 }
 
 .Form__coverageSelectLabel {
   display: inline-flex;
   flex-wrap: wrap;
-  align-items: center;
   gap: 12px;
+  align-items: center;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -108,9 +108,14 @@ function renderRegionSelectOptions() {
 function renderError(message) {
   errorMessage.innerHTML = message
   form.classList.add('Form--serverError')
+  textarea.setAttribute('aria-errormessage', 'form_error')
+  textarea.setAttribute('aria-invalid', 'true')
   textarea.addEventListener(
     'input',
     () => {
+      textarea.removeAttribute('aria-errormessage')
+      textarea.removeAttribute('aria-invalid')
+      errorMessage.innerHTML = ''
       form.classList.remove('Form--serverError')
     },
     {

--- a/client/view/Skip/Skip.css
+++ b/client/view/Skip/Skip.css
@@ -1,0 +1,18 @@
+.Skip {
+  position: absolute;
+  top: 25px;
+  left: 32px;
+  z-index: 10;
+  padding: 5px;
+  overflow: hidden;
+  font-size: 16px;
+  background: var(--bg-highlited-hover);
+  border: none;
+  border-radius: 4px;
+}
+
+.Skip:not(:focus) {
+  width: 0;
+  height: 0;
+  opacity: 0%;
+}

--- a/client/view/Skip/Skip.css
+++ b/client/view/Skip/Skip.css
@@ -1,6 +1,6 @@
 .Skip {
   position: absolute;
-  top: 25px;
+  top: 26px;
   left: 32px;
   z-index: 10;
   padding: 5px;

--- a/client/view/Skip/Skip.js
+++ b/client/view/Skip/Skip.js
@@ -1,0 +1,6 @@
+let skip = document.querySelector('[data-id=skip]')
+let form = document.querySelector('[data-id=query_text_area]')
+
+skip.addEventListener('click', () => {
+  form.focus()
+})


### PR DESCRIPTION
![Снимок экрана от 2022-08-19 22-54-10](https://user-images.githubusercontent.com/19343/185705693-1fc1e94e-279e-45ca-934f-02fb39c392c8.png)


- [x] Add `Skip to Browserslist preview form` button for keyboard-only users (Closes https://github.com/browserslist/browsersl.ist/issues/389)
- [x] Use semantic `<label>` tag for textarea label and connect them with `for`
- [x] Better screen reader support for error text
  - [x] Add `role=alert` so any text updates will be pronounced on text changes
  - [x] Add semantic `aria-errormessage` and `aria-invalid` to textarea with bad value
  - [x] Remove initial text in error’s div, so screen reader will not confuse users

Small changes:
- [x] Increase error text font to make it more readable
- [x] Replace `<p>` to `<div>` since it is not part of text flow to be a paragraph. Also, it solves the dynamic content problem with server could send tags invalid for `<p>`
- [x] Also Stylelint sorted `Form.css`
- [x] Form and result now use `<main>` instead of `<article>`. It is not a text, but the main element of website.
- [x] Links and website description now use `<header>` because it is closer to header. It will improve section navigation in screen reader.