### PR TITLE
Auto add `in region` to usage stats query with the specified region in the parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://browsersl.ist/api/browsers?q=defaults&region=alt-ww
 // https://browsersl.ist/api/browsers?q=>0.3%&region=alt-as
 
 {
-  "query": ">0.3%",
+  "query": ">0.3% in alt-as", // Append `in region` to audience coverage queries
   "region": "alt-as",
   "coverage": 92.64,
   "versions": {

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -7,7 +7,7 @@ let { version: bv } = importJSON('../node_modules/browserslist/package.json')
 let { version: cv } = importJSON('../node_modules/caniuse-lite/package.json')
 
 export const QUERY_DEFAULTS = 'defaults'
-export const REGION_GLOBAL = 'Global'
+export const REGION_GLOBAL = 'alt-ww'
 
 export default async function getBrowsers(query, region) {
   let browsersByQuery = []

--- a/server/lib/get-query-with-region.js
+++ b/server/lib/get-query-with-region.js
@@ -1,0 +1,34 @@
+import browserslist from 'browserslist'
+
+export default function getQueryWithRegion(query, region) {
+  let queryParsed = browserslist.parse(query)
+  let queryParsedModified = queryParsed.map(expression => {
+    if (expression.type === 'popularity') {
+      return {
+        compose: expression.compose,
+        place: region,
+        popularity: expression.popularity,
+        query: [expression.query, 'in', region].join(' '),
+        sign: expression.sign,
+        type: 'popularity_in_place'
+      }
+    }
+    return expression
+  })
+
+  return getQueryFromQueryParsed(queryParsedModified)
+}
+
+function getQueryFromQueryParsed(browserslistParsed) {
+  return browserslistParsed.reduce(
+    (updatedQuery, { query: currentQuery, compose }, i) => {
+      // The first parsed query always contains `or`
+      if (i === 0) {
+        return currentQuery
+      } else {
+        return [updatedQuery, compose, currentQuery].join(' ')
+      }
+    },
+    ''
+  )
+}

--- a/server/test/browsers.test.js
+++ b/server/test/browsers.test.js
@@ -6,7 +6,7 @@ import getBrowsers from '../lib/get-browsers.js'
 test('Throws error for wrong browserslist `query`', async () => {
   let error
   try {
-    await getBrowsers('wrong', 'Global')
+    await getBrowsers('wrong', 'alt-ww')
   } catch (e) {
     error = e
   }
@@ -15,7 +15,7 @@ test('Throws error for wrong browserslist `query`', async () => {
 })
 
 test('Returns multiple browser names and versions by `>1%` query', async () => {
-  let data = await getBrowsers('>1%', 'Global')
+  let data = await getBrowsers('>1%', 'alt-ww')
   let browsersNames = data.browsers
   let browsersVersions = Object.keys(browsersNames[0])
 
@@ -35,7 +35,7 @@ test('Throws error for wrong Can I Use `region`', async () => {
 })
 
 test('Returns Node.js versions without coverage`', async () => {
-  let data = await getBrowsers('Node > 0', 'Global')
+  let data = await getBrowsers('Node > 0', 'alt-ww')
 
   equal(data.browsers[0].name, 'Node')
   equal(data.browsers[0].coverage, null)
@@ -43,7 +43,7 @@ test('Returns Node.js versions without coverage`', async () => {
 
 test('Сoverage of all browsers should differ in different regions', async () => {
   let continentData = await getBrowsers('>1%', 'Global')
-  let countryData = await getBrowsers('>1%', 'IT')
+  let continentData = await getBrowsers(query, 'alt-as')
 
   notEqual(continentData.coverage, countryData.coverage)
 })

--- a/server/test/browsers.test.js
+++ b/server/test/browsers.test.js
@@ -1,5 +1,5 @@
 import test from 'node:test'
-import { equal, notEqual, ok, match } from 'node:assert'
+import { equal, deepEqual, notEqual, ok, match, notDeepEqual } from 'node:assert'
 
 import getBrowsers from '../lib/get-browsers.js'
 
@@ -41,11 +41,13 @@ test('Returns Node.js versions without coverage`', async () => {
   equal(data.browsers[0].coverage, null)
 })
 
-test('Сoverage of all browsers should differ in different regions', async () => {
-  let continentData = await getBrowsers('>1%', 'Global')
+test('Should show different coverage statistics for another regions', async () => {
+  let query = '>0.1% and supports es6-module'
   let continentData = await getBrowsers(query, 'alt-as')
+  let countryData = await getBrowsers(query, 'IT')
 
   notEqual(continentData.coverage, countryData.coverage)
+  notDeepEqual(continentData.browsers, countryData.browsers)
 })
 
 test('Сoverage for browser should differ in different regions', async () => {
@@ -56,4 +58,11 @@ test('Сoverage for browser should differ in different regions', async () => {
   let countryBrowser = countryData.browsers[0]
 
   notEqual(continentBrowser.coverage, countryBrowser.coverage)
+})
+
+test('Should transform query with type `popularity` to `popularity_in_place`', async () => {
+  deepEqual(
+    await getBrowsers('>0.1% and <10%, dead', 'FR'),
+    await getBrowsers('>0.1% in FR and <10% in FR, dead', 'FR')
+  )
 })

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -18,12 +18,12 @@ test('Integration tests', async t => {
   )
 
   await t.test(
-    'responses `Global` region for `/browsers` route without `region` param',
+    'responses `alt-ww` region for `/browsers` route without `region` param',
     async () => {
       let url = new URL(`api/browsers`, base)
       let response = await fetch(url)
       let data = await response.json()
-      equal(data.region, 'Global')
+      equal(data.region, 'alt-ww')
     }
   )
 


### PR DESCRIPTION
It seems to me that a rather particular scenario, when the user writes `>0.1`, selects a region. And we need to automatically add the `in region` to users query.

```
Now deepEquals: 
    await getBrowsers('>0.1% and <10%, dead', 'FR'),
    await getBrowsers('>0.1% in FR and <10% in FR, dead', 'FR')
```

- [x] Added `getQueryWithRegion(query, region)` for modify query. Convert `popularity` expressions to `popularity_in_place`
- [x] Added `getQueryFromQueryParsed`. It's `browserslist.fromParse` for `browserslist.parse` 
- [x] Added a test to check the query conversion
- [x] Return updated query in JSON response

**Additionaly**
- [x] Update test `different coverage statistics for another regions`
- [x] Replace unused alias `Global` to `alt-ww`




**Bug** — Closes #443
https://browsersl.ist/?q=%3E1%25&region=alt-as 

![image](https://user-images.githubusercontent.com/22644149/185709651-dc092794-dee4-4df7-b322-ff0a95c397ff.png)

