### PR TITLE
Temporary demo with old caniuse-1.0.30001379

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@csstools/postcss-oklab-function": "^1.1.1",
     "autoprefixer": "^10.4.8",
-    "caniuse-lite": "^1.0.30001380",
+    "caniuse-lite": "^1.0.30001379",
     "jstransformer-markdown-it": "^3.0.0",
     "postcss": "^8.4.16",
     "postcss-media-minmax": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
       '@csstools/postcss-oklab-function': ^1.1.1
       '@size-limit/file': ^8.0.1
       autoprefixer: ^10.4.8
-      caniuse-lite: ^1.0.30001380
+      caniuse-lite: ^1.0.30001379
       jstransformer-markdown-it: ^3.0.0
       postcss: ^8.4.16
       postcss-media-minmax: ^5.0.0
@@ -58,7 +58,7 @@ importers:
     dependencies:
       '@csstools/postcss-oklab-function': 1.1.1_postcss@8.4.16
       autoprefixer: 10.4.8_postcss@8.4.16
-      caniuse-lite: 1.0.30001380
+      caniuse-lite: 1.0.30001379
       jstransformer-markdown-it: 3.0.0
       postcss: 8.4.16
       postcss-media-minmax: 5.0.0_postcss@8.4.16
@@ -73,10 +73,10 @@ importers:
   server:
     specifiers:
       browserslist: ^4.21.3
-      caniuse-lite: ^1.0.30001380
+      caniuse-lite: ^1.0.30001379
     dependencies:
       browserslist: 4.21.3
-      caniuse-lite: 1.0.30001380
+      caniuse-lite: 1.0.30001379
 
 packages:
 
@@ -531,7 +531,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.3
-      caniuse-lite: 1.0.30001380
+      caniuse-lite: 1.0.30001379
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -587,7 +587,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001380
+      caniuse-lite: 1.0.30001379
       electron-to-chromium: 1.4.225
       node-releases: 2.0.6
       update-browserslist-db: 1.0.5_browserslist@4.21.3
@@ -634,8 +634,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /caniuse-lite/1.0.30001380:
-    resolution: {integrity: sha512-OO+pPubxx16lkI7TVrbFpde8XHz66SMwstl1YWpg6uMGw56XnhYVwtPIjvX4kYpzwMwQKr4DDce394E03dQPGg==}
+  /caniuse-lite/1.0.30001379:
+    resolution: {integrity: sha512-zXf+qxuN8OJrK5Bl5HbJg8cc5/Zm01WNW4ooVWUh92YlKqQZW3fwN5lXLB+kI8wkP5vTWkIIN+rutZuJhf4ykw==}
     dev: false
 
   /chalk/2.4.2:

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -71,9 +71,6 @@ export default async function getBrowsers(query, region) {
 
   let coverage = roundNumber(browserslist.coverage(browsersByQuery, region))
 
-  // BUG `caniuse-db` returns coverage >100% https://github.com/Fyrd/caniuse/issues/6426
-  coverage = coverage > 100 ? 100 : coverage
-
   return {
     query,
     region,

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "browserslist": "^4.21.3",
-    "caniuse-lite": "^1.0.30001380"
+    "caniuse-lite": "^1.0.30001379"
   }
 }


### PR DESCRIPTION
Temporary demo branch to monitor changes in caniuse statistics. https://github.com/Fyrd/caniuse/issues/6426

**Before. Previous version (1.0.30001379) with stats bug**
https://preview-451---browserslist-vw3nqlhdtq-ue.a.run.app/?q=%3E+0.5%25+in+RU&region=RU

**After. Current version (1.0.30001380)**
https://browsersl.ist/?q=%3E+0.5%25+in+RU&region=RU

![tg_image_3907698296](https://user-images.githubusercontent.com/22644149/185795257-5dd1fbff-9c0f-49cc-bda8-5366032f8003.jpeg)