### PR TITLE
Be ready for response wrong order

### DIFF
--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -87,7 +87,7 @@
   pointer-events: initial;
 }
 
-.Form.Form--serverError:not(.Form--loaded) .Form__hint--error {
+.Form.Form--serverError:not(.Form--loading) .Form__hint--error {
   opacity: 100%;
 }
 
@@ -100,7 +100,7 @@
   pointer-events: initial;
 }
 
-.Form--loaded .Form__loader {
+.Form--loading .Form__loader {
   opacity: 100%;
 }
 

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -134,7 +134,7 @@ async function updateStatsView(query, region) {
   let data
   let error
 
-  form.classList.add('Form--loaded')
+  form.classList.add('Form--loading')
 
   try {
     data = await loadBrowsersData(query, region)
@@ -142,7 +142,7 @@ async function updateStatsView(query, region) {
     error = e
   }
 
-  form.classList.remove('Form--loaded')
+  form.classList.remove('Form--loading')
 
   if (error) {
     renderError(error)

--- a/client/view/Form/loadBrowsersData.js
+++ b/client/view/Form/loadBrowsersData.js
@@ -1,0 +1,36 @@
+let lastRequest = 0
+
+export default async function loadBrowsersData(query, region) {
+  lastRequest += 1
+  let request = lastRequest
+  let response
+
+  try {
+    let urlParams = new URLSearchParams({ q: query, region })
+    response = await fetch(`/api/browsers?${urlParams}`)
+
+    if (request !== lastRequest) {
+      return false
+    }
+  } catch (error) {
+    throw new Error('Network error. Check that you are online.')
+  }
+
+  let data = await response.json()
+
+  if (!response.ok) {
+    if (data.message === 'Custom usage statistics was not provided') {
+      throw new Error(`This website does not support in my stats queries yet. Run Browserslist
+ <a href="https://github.com/browserslist/browserslist#custom-usage-data" class="Link">locally</a>.`)
+    }
+
+    if (response.status === 500) {
+      throw new Error(`Server error. <a href="https://github.com/browserslist/browserl.ist" class="Link">
+  Report an issue</a> to our repository.`)
+    }
+
+    throw new Error(data.message)
+  }
+
+  return data
+}


### PR DESCRIPTION
- [x] Render data always by last request (Closes #445)
- [x] Moved `loadBrowsersData(query, region)` to separate module
- [x] BEM modificator `Form--loaded` rename to `Form--loading`

