### PR TITLE
Fix empty href in hidden `queryLinks`

### DIFF
--- a/client/view/QueryLink/QueryLink.js
+++ b/client/view/QueryLink/QueryLink.js
@@ -5,7 +5,7 @@ let links = document.querySelectorAll('a.QueryLink')
 
 links.forEach(item => {
   let queryAttr = item.getAttribute('data-query')
-  let query = queryAttr || item.innerText.trim()
+  let query = queryAttr || item.textContent.trim()
 
   item.setAttribute('href', `?q=${query}`)
 


### PR DESCRIPTION
Replaced innerText with textContent, that has access to hidden content

![image](https://user-images.githubusercontent.com/22644149/185994831-87e0c1ee-078c-400d-b220-49c1cb198099.png)
