### PR TITLE
Add browserslist-lint results

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Update dependencies
-        run: pnpm update -r caniuse-lite browserslist
+        run: pnpm update -r caniuse-lite browserslist browserslist-lint
       - name: Check dependencies
         id: changes
         run: node ./scripts/check-changes.js

--- a/README.md
+++ b/README.md
@@ -27,21 +27,27 @@ https://browsersl.ist/api/browsers?q=defaults&region=alt-ww
 ### Response example
 
 ```js
-// https://browsersl.ist/api/browsers?q=>0.3%&region=alt-as
+// https://browsersl.ist/api/browsers?q=>defaults+and+supports+es6-module&region=alt-as
 
 {
   "query": ">0.3%",
+  "lint": [
+    {
+      "id": "countryWasIgnored",
+      "message": "Less than 80% coverage in `China`, `Nigeria`, `Tanzania`, `Ghana`, and `Uganda` regions"
+    }
+  ],
   "region": "alt-as",
-  "coverage": 92.64,
+  "coverage": 88.44,
   "versions": {
     "browserslist": "4.21.3",
-    "caniuse": "1.0.30001377"
+    "caniuse": "1.0.30001381"
   },
   "browsers": [
     {
       "id": "chrome",
       "name": "Chrome",
-      "coverage": 17.04,
+      "coverage": 17.06,
       "versions": {
         "102": 0.72,
         "103": 16.32

--- a/client/.size-limit.json
+++ b/client/.size-limit.json
@@ -8,6 +8,6 @@
     "name": "All scripts to execute",
     "path": "dist/*.js",
     "gzip": false,
-    "limit": "10 KB"
+    "limit": "15 KB"
   }
 ]

--- a/client/index.html
+++ b/client/index.html
@@ -54,6 +54,7 @@
         </label>
         <p class="Form__loader">Loading…</p>
         <div id="form_error" class="Form__hint Form__hint--error" data-id="error_message" role="alert"></div>
+        <div id="form_warning" class="Form__hint Form__hint--warning" data-id="warning_message" role="alert"></div>
       </div>
       <div class="Form__coverage" data-id="region_coverage" hidden>
         <h2>Audience coverage: <span data-id="region_coverage_counter"></span></h2>

--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -49,6 +49,11 @@
   transition: opacity 0.2s linear;
 }
 
+.Form__hint a {
+  color: inherit;
+  pointer-events: initial;
+}
+
 .Form__loader {
   pointer-events: none;
 }
@@ -82,12 +87,15 @@
   color: var(--error);
 }
 
-.Form__hint--error a {
-  color: inherit;
-  pointer-events: initial;
+.Form--serverError:not(.Form--loading) .Form__hint--error {
+  opacity: 100%;
 }
 
-.Form.Form--serverError:not(.Form--loading) .Form__hint--error {
+.Form__hint--warning {
+  color: var(--warning);
+}
+
+.Form--serverWarning:not(.Form--loading) .Form__hint--warning {
   opacity: 100%;
 }
 

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -15,6 +15,7 @@ let regionCoverageSelect = document.querySelector(
   '[data-id=region_coverage_select]'
 )
 let errorMessage = document.querySelector('[data-id=error_message]')
+let warningMessage = document.querySelector('[data-id=warning_message]')
 
 form.addEventListener('submit', handleFormSubmit)
 
@@ -63,6 +64,7 @@ export function setFormValues({ query, region }) {
   if (query) {
     textarea.value = query
     form.classList.remove('Form--serverError')
+    form.classList.remove('Form--serverWarning')
   }
 
   let isRegionExists = regionList.includes(region)
@@ -125,6 +127,19 @@ function renderError(message) {
   )
 }
 
+function renderWarning(message) {
+  warningMessage.innerHTML = message
+  form.classList.add('Form--serverWarning')
+  textarea.addEventListener(
+    'input',
+    () => {
+      warningMessage.innerHTML = ''
+      form.classList.remove('Form--serverWarning')
+    },
+    { once: true }
+  )
+}
+
 async function updateStatsView(query, region) {
   if (query.length === 0) {
     toggleShowStats(false)
@@ -153,7 +168,12 @@ async function updateStatsView(query, region) {
     return
   }
 
-  let { browsers, coverage, versions } = data
+  let { lint, browsers, coverage, versions } = data
+
+  if (lint.length > 0) {
+    let linterWarning = lint.map(({ message }) => message).join('.<br />')
+    renderWarning(linterWarning)
+  }
 
   toggleShowStats(true)
   updateBrowsersStats(browsers)

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -171,7 +171,11 @@ async function updateStatsView(query, region) {
   let { lint, browsers, coverage, versions } = data
 
   if (lint.length > 0) {
-    let linterWarning = lint.map(({ message }) => message).join('.<br />')
+    let linterWarning = lint
+      .map(({ message }) =>
+        message.replace(/`([^`]+)`/g, '<strong>$1</strong>')
+      )
+      .join('.<br />')
     renderWarning(linterWarning)
   }
 

--- a/client/view/QueryLink/QueryLink.js
+++ b/client/view/QueryLink/QueryLink.js
@@ -5,7 +5,7 @@ let links = document.querySelectorAll('a.QueryLink')
 
 links.forEach(item => {
   let queryAttr = item.getAttribute('data-query')
-  let query = queryAttr || item.innerText.trim()
+  let query = queryAttr || item.textContent.trim()
 
   item.setAttribute('href', `?q=${query}`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,11 @@ importers:
   server:
     specifiers:
       browserslist: ^4.21.3
+      browserslist-lint: ^0.1.0
       caniuse-lite: ^1.0.30001381
     dependencies:
       browserslist: 4.21.3
+      browserslist-lint: 0.1.0
       caniuse-lite: 1.0.30001381
 
 packages:
@@ -581,6 +583,14 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
+
+  /browserslist-lint/0.1.0:
+    resolution: {integrity: sha512-WtEu1yKfpqirMLqib+6fNzPxm2Wj7LlPBhaBD6rRjI+lL8KPTsbqMXXIzOlQOpTHkGTVUe+oYQFzwssYIis96w==}
+    hasBin: true
+    dependencies:
+      browserslist: 4.21.3
+      picocolors: 1.0.0
+    dev: false
 
   /browserslist/4.21.3:
     resolution: {integrity: sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,11 +73,11 @@ importers:
   server:
     specifiers:
       browserslist: ^4.21.3
-      browserslist-lint: ^0.1.0
+      browserslist-lint: ^0.1.1
       caniuse-lite: ^1.0.30001381
     dependencies:
       browserslist: 4.21.3
-      browserslist-lint: 0.1.0
+      browserslist-lint: 0.1.1
       caniuse-lite: 1.0.30001381
 
 packages:
@@ -584,8 +584,8 @@ packages:
       fill-range: 7.0.1
     dev: true
 
-  /browserslist-lint/0.1.0:
-    resolution: {integrity: sha512-WtEu1yKfpqirMLqib+6fNzPxm2Wj7LlPBhaBD6rRjI+lL8KPTsbqMXXIzOlQOpTHkGTVUe+oYQFzwssYIis96w==}
+  /browserslist-lint/0.1.1:
+    resolution: {integrity: sha512-JnPl0CwekPRYWG+TjdtFhJ+JaPnqx0aM9tX3lUJx9mUVYTfeWGEzyJcUakhsVb0uWhc4nwUrIwUYB7Bsf7KAxw==}
     hasBin: true
     dependencies:
       browserslist: 4.21.3

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -1,6 +1,7 @@
 import { agents as caniuseAgents, region as caniuseRegion } from 'caniuse-lite'
 import { readFileSync } from 'node:fs'
 import browserslist from 'browserslist'
+import { lint } from 'browserslist-lint'
 import { URL } from 'node:url'
 
 let { version: bv } = importJSON('../node_modules/browserslist/package.json')
@@ -76,6 +77,7 @@ export default async function getBrowsers(query, region) {
 
   return {
     query,
+    lint: lint(query).message,
     region,
     coverage,
     versions: {

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -77,7 +77,7 @@ export default async function getBrowsers(query, region) {
 
   return {
     query,
-    lint: lint(query).message,
+    lint: lint(query),
     region,
     coverage,
     versions: {

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "browserslist": "^4.21.3",
+    "browserslist-lint": "^0.1.0",
     "caniuse-lite": "^1.0.30001381"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "browserslist": "^4.21.3",
-    "browserslist-lint": "^0.1.0",
+    "browserslist-lint": "^0.1.1",
     "caniuse-lite": "^1.0.30001381"
   }
 }


### PR DESCRIPTION
**Changes**
- [x] Added `lint: [ { type, message }, ... ]` field to HTTP API response
_UPD: it seems the server code is not updated in the preview_
- [x] Added output in the client. Create warning, similar errors
- [x] Fixed Node.js examples lint error (https://github.com/browserslist/lint/pull/1)
- [x] Updated README.md

**Questions**
- How to display multiple warnings? (**design**) Now I output with `. <br />`
![image](https://user-images.githubusercontent.com/22644149/186018418-4e3bb4b2-9398-4eca-b388-3544337b1fc6.png)
- Should we do something for warning's a11y?
- Should we automatically update `browserslist-lint` every day (as `browserslist` and `caniuse-lite`)?
- Our first example with `defaults and supports es6-module` contains coverage errors :(

Closes #390 
