### PR TITLE
Add clicked state and improve extand button

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -122,7 +122,7 @@
       <h3 class="DocSection__header">Start with the default configuration</h3>
 
       <p>You can pick a sound set of versions with the <a class="QueryLink"><code>defaults</code></a> query which is
-        a shortcut for <a class="QueryLink"><code>> 0.5%, last 2 versions, Firefox ESR, not dead</code></a>.
+        a shortcut for <code>> 0.5%, last 2 versions, Firefox ESR, not dead</code>.
         It matches recent versions of popular and supported browsers worldwide and includes
         Firefox Extended Support Release which is updated roughly annually.
       </p>

--- a/client/view/DocSection/DocSection.css
+++ b/client/view/DocSection/DocSection.css
@@ -38,6 +38,11 @@ summary .DocSection__subHeader {
 .DocSection details summary {
   width: fit-content;
   cursor: pointer;
+  user-select: none;
+}
+
+.DocSection details summary:active {
+  transform: scale(95%);
 }
 
 .DocSection details[open] summary {

--- a/client/view/QueryLink/QueryLink.css
+++ b/client/view/QueryLink/QueryLink.css
@@ -1,6 +1,6 @@
 .QueryLink {
+  display: inline-block;
   text-decoration: none;
-  cursor: pointer;
 }
 
 @media (hover) {
@@ -11,11 +11,10 @@
 }
 
 .QueryLink > code {
-  padding: 0 4px;
-  color: var(--accent);
-  background-color: var(--text-highlited);
-  border-radius: 4px;
   display: inline-block;
   padding: 0 4px;
   font-weight: 300;
+  color: var(--accent);
+  background-color: var(--text-highlited);
+  border-radius: 4px;
 }

--- a/client/view/base/base.css
+++ b/client/view/base/base.css
@@ -8,7 +8,18 @@
 
 body {
   margin: 0;
-  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    sans-serif;
   -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -25,10 +36,20 @@ p {
 }
 
 code {
-  font-family: 'Martian Mono', monospace;
+  font-family: "Martian Mono", monospace;
   font-size: 13px;
-  line-height: 22px;
   font-weight: 600;
+  line-height: 22px;
+}
+
+a,
+button {
+  cursor: pointer;
+}
+
+a:active,
+button:active {
+  transform: scale(95%);
 }
 
 [hidden] {


### PR DESCRIPTION
- [x] Add `:active` state for all buttons and links
- [x] Add `display: inline-block` to `QueryLink` to reduce line breaks there
  - [x] Replace longest `QueryLink` to just `<code>` since it is explanation
- [x] Fix the bug when fast clicks on `Advanced` select the text in the “button”

Closes https://github.com/browserslist/browsersl.ist/issues/407

Closes https://github.com/browserslist/browsersl.ist/issues/395