### PR TITLE
Add links to npm package

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -82,10 +82,10 @@
 
         <div class="BrowsersStat__toolsVersions">
           <p class="BrowsersStat__toolsVersionsItem">
-            Browserslist version <span data-id="browsers_list_version"></span>.
+            Browserslist version <a class="BrowsersStat__toolLink" target="_blank" href="https://www.npmjs.com/package/browserslist" data-id="browsers_list_version"></a>.
           </p>
           <p class="BrowsersStat__toolsVersionsItem">
-            Data provided by caniuse-db <span data-id="can_i_use_version"></span>.
+            Data provided by caniuse-db <a class="BrowsersStat__toolLink" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="can_i_use_version"></a>.
           </p>
         </div>
       </div>

--- a/client/index.html
+++ b/client/index.html
@@ -82,10 +82,10 @@
 
         <div class="BrowsersStat__toolsVersions">
           <p class="BrowsersStat__toolsVersionsItem">
-            Browserslist version <a class="BrowsersStat__toolLink" target="_blank" href="https://www.npmjs.com/package/browserslist" data-id="browsers_list_version"></a>.
+            Browserslist version <a class="BrowsersStat__toolLink" target="_blank" href="https://www.npmjs.com/package/browserslist" data-id="browsers_list_version"></a>
           </p>
           <p class="BrowsersStat__toolsVersionsItem">
-            Data provided by caniuse-db <a class="BrowsersStat__toolLink" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="can_i_use_version"></a>.
+            Data provided by caniuse-db <a class="BrowsersStat__toolLink" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="can_i_use_version"></a>
           </p>
         </div>
       </div>

--- a/client/view/BrowserStats/BrowsersStat.css
+++ b/client/view/BrowserStats/BrowsersStat.css
@@ -176,3 +176,7 @@
   font-size: 14px;
   line-height: 20px;
 }
+
+.BrowsersStat__toolLink {
+  color: currentcolor;
+}


### PR DESCRIPTION
I added links to npm packages from footer with `browserslist` and `caniuse-lite` versions.

1. It will be better to highlight versions a little
2. Users can use these links to check that it is really the latest versions