### PR TITLE
Add `target="blank"` to Badges

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -24,10 +24,10 @@
         <img class="Article__logo" src="./view/Article/browserlist_logo.svg" alt="">
         Browserslist
       </h1>
-      <a class="Badge" href="https://github.com/browserslist/browserslist">
+      <a class="Badge" href="https://github.com/browserslist/browserslist" target="_blank">
         <img src="./view/Badge/github_logo.svg" alt="Count of GitHub stars" class="Badge__logo Badge__logo--github"> 11K
       </a>
-      <a class="Badge" href="https://twitter.com/Browserslist">
+      <a class="Badge" href="https://twitter.com/Browserslist" target="_blank">
         <img src="./view/Badge/twitter_logo.svg" alt="Count of Twitter followers" class="Badge__logo"> 1728
       </a>
     </div>
@@ -429,7 +429,7 @@
   </article>
 
   <footer class="Footer">
-    <a class="Badge" href="https://github.com/browserslist/browsersl.ist">
+    <a class="Badge" href="https://github.com/browserslist/browsersl.ist" target="_blank">
       <img src="./view/Badge/github_logo.svg" alt="" class="Badge__logo Badge__logo--github"> Website source code
     </a>
   </footer>


### PR DESCRIPTION
Should we set `rel="noopener noreferrer"` here and everywhere?

Or do wetotal trust the resources we are referring to and this is unnecessary? 