### PR TITLE
`@media` queries refactoring

### DIFF
--- a/client/view/Base/Base.css
+++ b/client/view/Base/Base.css
@@ -1,19 +1,15 @@
 @import "./colors.css";
 
 :root {
-  --block-padding: 24px 32px;
-  --block-width: 50%;
-}
+  --block-padding: 16px 24px;
+  --block-width: initial;
 
-@media (width <= 740px) {
-  :root {
-    --block-width: initial;
+  @media (width > 460px) {
+    --block-padding: 24px 32px;
   }
-}
 
-@media (width <= 460px) {
-  :root {
-    --block-padding: 16px 24px;
+  @media (width > 740px) {
+    --block-width: 50%;
   }
 }
 

--- a/client/view/Browsers/Browsers.css
+++ b/client/view/Browsers/Browsers.css
@@ -9,14 +9,12 @@
 }
 
 .Browsers_results {
-  columns: 2;
-  column-fill: balance;
-
-  @media (width >= 740px) and (width <= 1200px) {
-    columns: 1;
+  @media (width > 600px) {
+    columns: 2;
+    column-fill: balance;
   }
 
-  @media (width <= 600px) {
+  @media (width > 740px) and (width <= 1200px) {
     columns: 1;
   }
 }

--- a/client/view/Docs/Docs.css
+++ b/client/view/Docs/Docs.css
@@ -9,6 +9,7 @@
 
 .Docs section {
   padding: 16px;
+  margin: 0 -16px;
   background-color: var(--bg-highlited);
   border-radius: 8px;
 
@@ -16,8 +17,8 @@
     margin-top: 24px;
   }
 
-  @media (width <= 740px) {
-    margin: 0 -16px;
+  @media (width > 740px) {
+    margin: 0;
   }
 }
 

--- a/client/view/Hedgehog/Hedgehog.css
+++ b/client/view/Hedgehog/Hedgehog.css
@@ -2,28 +2,29 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 16px;
+  padding: 32px 0;
   align-items: center;
   justify-content: center;
   height: 100%;
   color: var(--text-secondary);
 
-  @media (width <= 740px) {
-    gap: 16px;
-    padding: 32px 0;
+  @media (width > 740px) {
+    gap: 32px;
+    padding: 0;
   }
 }
 
 .Hedgehog_image {
-  width: 100%;
-  max-width: 380px;
+  max-width: 100%;
+  max-height: 300px;
   aspect-ratio: 380 / 316;
   object-fit: contain;
 
-  @media (width <= 740px) {
-    max-width: 100%;
-    height: initial;
-    max-height: 300px;
+  @media (width > 740px) {
+    width: 100%;
+    max-width: 380px;
+    max-height: auto;
   }
 }
 

--- a/client/view/Interactive/Interactive.css
+++ b/client/view/Interactive/Interactive.css
@@ -6,13 +6,11 @@
   right: calc(-1 * (100vw - 100%));
   box-sizing: border-box;
   display: flex;
-  flex-basis: 0;
   flex-direction: column;
   flex-grow: 1;
   gap: 16px;
   width: var(--block-width);
   height: 100vh;
-  max-height: 100vh;
   padding: var(--block-padding);
   overflow-y: scroll;
   background-color: var(--bg-highlited);

--- a/client/view/Interactive/Interactive.css
+++ b/client/view/Interactive/Interactive.css
@@ -1,5 +1,4 @@
 .Interactive {
-  position: fixed;
   top: 0;
 
   /* Hide scrollbar */
@@ -10,16 +9,13 @@
   flex-grow: 1;
   gap: 16px;
   width: var(--block-width);
-  height: 100vh;
   padding: var(--block-padding);
-  overflow-y: scroll;
   background-color: var(--bg-highlited);
 
-  @media (width <= 740px) {
-    position: initial;
-    height: initial;
-    max-height: initial;
-    overflow: visible;
+  @media (width > 740px) {
+    position: fixed;
+    height: 100vh;
+    overflow-y: scroll;
   }
 }
 

--- a/client/view/Interactive/Interactive.css
+++ b/client/view/Interactive/Interactive.css
@@ -1,8 +1,4 @@
 .Interactive {
-  top: 0;
-
-  /* Hide scrollbar */
-  right: calc(-1 * (100vw - 100%));
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -14,6 +10,9 @@
 
   @media (width > 740px) {
     position: fixed;
+    top: 0;
+    /* Hide scrollbar */
+    right: calc(-1 * (100vw - 100%));
     height: 100vh;
     overflow-y: scroll;
   }

--- a/client/view/Intro/Intro.css
+++ b/client/view/Intro/Intro.css
@@ -28,13 +28,13 @@
 
 .Intro_about {
   margin: 16px 0;
-  font-size: 25px;
-  line-height: 32px;
+  font-size: 16px;
+  line-height: 22px;
   letter-spacing: 0.01em;
 
-  @media (width <= 460px) {
-    font-size: 16px;
-    line-height: 22px;
+  @media (width > 460px) {
+    font-size: 25px;
+    line-height: 32px;
   }
 }
 


### PR DESCRIPTION
- [x] Reversed `@media` queries (mobile-first) to reduce the number of properties and remove not obvious `initial` values. Development started before the mobile version appeared
- [x] Put `@media` inside `:root`
- [x] Removed unused rules `flex-basis` and `max-height` from `Interactive` 

I tested the screen resolutions — everything looks like before