### PR TITLE
Fix version sorting

### DIFF
--- a/client/view/Browsers/Browsers.js
+++ b/client/view/Browsers/Browsers.js
@@ -39,11 +39,27 @@ function createLine(...items) {
   return tr
 }
 
+let getVersion = version => {
+  // Show Safari Technology Preview at the top of the list
+  if (version === 'TP') {
+    return Infinity
+  }
+  if (version.includes('-')) {
+    let minorVersionRange = version.split('-')
+    let lastMinorVersion = minorVersionRange[minorVersionRange.length - 1]
+    return parseInt(lastMinorVersion, 10)
+  }
+
+  return parseInt(version, 10)
+}
+
 export function updateBrowsersStats(data) {
   table.replaceChildren(
     ...data.map(({ id, name, versions: versionsInput }) => {
       let versions = Object.entries(versionsInput)
-        .sort(([versionA], [versionB]) => versionB - versionA)
+        .sort(([versionA], [versionB]) => {
+          return getVersion(versionB) - getVersion(versionA)
+        })
         .map(([version, coverage]) => {
           return {
             version,

--- a/client/view/Browsers/Browsers.js
+++ b/client/view/Browsers/Browsers.js
@@ -39,11 +39,7 @@ function createLine(...items) {
   return tr
 }
 
-let getVersion = version => {
-  // Show Safari Technology Preview at the top of the list
-  if (version === 'TP') {
-    return Infinity
-  }
+let parseVersion = version => {
   if (version.includes('-')) {
     let minorVersionRange = version.split('-')
     let lastMinorVersion = minorVersionRange[minorVersionRange.length - 1]
@@ -58,7 +54,12 @@ export function updateBrowsersStats(data) {
     ...data.map(({ id, name, versions: versionsInput }) => {
       let versions = Object.entries(versionsInput)
         .sort(([versionA], [versionB]) => {
-          return getVersion(versionB) - getVersion(versionA)
+          // Show Safari Technology Preview at the top of the list
+          if (versionA === 'TP') {
+            return -1
+          }
+
+          return parseVersion(versionB) - parseVersion(versionA)
         })
         .map(([version, coverage]) => {
           return {

--- a/client/view/Browsers/Browsers.js
+++ b/client/view/Browsers/Browsers.js
@@ -47,10 +47,10 @@ let getVersion = version => {
   if (version.includes('-')) {
     let minorVersionRange = version.split('-')
     let lastMinorVersion = minorVersionRange[minorVersionRange.length - 1]
-    return parseInt(lastMinorVersion, 10)
+    return Number(lastMinorVersion)
   }
 
-  return parseInt(version, 10)
+  return Number(version)
 }
 
 export function updateBrowsersStats(data) {


### PR DESCRIPTION
- [x] Fixed soring for minor versions (`'15.2-15.3' -> NaN`)
- [x] Showed Safari TP from above _(It seems to be hard coding, but it's still better than send to the client `release_date`)_

**Test query**

_Before_
https://browsersl.ist/?q=since+0+or+unreleased+versions+or+Node+%3E+0

_After_
https://preview-474---browserslist-vw3nqlhdtq-ue.a.run.app/?q=since+0+or+unreleased+versions+or+Node+%3E+0

Closes #472