### PR TITLE
Fix double `fetch()` 

### DIFF
--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -158,7 +158,7 @@ function changeUrl(query, region) {
     urlParams.set('region', region)
   }
 
-  history.pushState({}, query, '#' + urlParams)
+  history.pushState({}, '', '#' + urlParams)
 }
 
 function submitFormWithUrlParams() {

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -158,7 +158,7 @@ function changeUrl(query, region) {
     urlParams.set('region', region)
   }
 
-  location.hash = '#' + urlParams
+  history.pushState({}, query, '#' + urlParams)
 }
 
 function submitFormWithUrlParams() {


### PR DESCRIPTION
I found that after PR #476 double requests are sent.

![image](https://user-images.githubusercontent.com/22644149/188285942-c214a03d-d9c3-402c-8a0f-bd25cb3f0c9e.png)

I fixed double `submitForm()` with `fetch()` by removing unnessesary `hashchange` trigger.

- `location.hash` triggers `hashchange`
- `history.pushState` does not trigger `hashchange`