### PR TITLE
Improve the hint with errors/warnings

### DIFF
--- a/client/index.css
+++ b/client/index.css
@@ -2,6 +2,7 @@
 @import "./view/Base/Base.css";
 @import "./view/Browsers/Browsers.css";
 @import "./view/Hedgehog/Hedgehog.css";
+@import "./view/Alert/Alert.css";
 @import "./view/Bar/Bar.css";
 @import "./view/Versions/Versions.css";
 @import "./view/Intro/Intro.css";

--- a/client/index.html
+++ b/client/index.html
@@ -51,9 +51,11 @@
           <a class="QueryLink"><code>> 0.2% and not dead</code></a>
         </label>
         <p class="Form_loader">Loading…</p>
-        <div id="form_error" class="Form_hint is-error" data-id="form_error" role="alert"></div>
-        <div id="form_warning" class="Form_hint is-warning" data-id="form_warning" role="alert"></div>
       </div>
+
+      <div id="form_error" class="Form_hint is-error" data-id="form_error" role="alert" hidden></div>
+      <div id="form_warning" class="Form_hint is-warning" data-id="form_warning" role="alert" hidden></div>
+
       <div class="Form_coverage" data-id="form_coverage" hidden>
         <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>
         <label class="Form_region">

--- a/client/index.html
+++ b/client/index.html
@@ -53,8 +53,7 @@
         <p class="Form_loader">Loading…</p>
       </div>
 
-      <div id="form_error" class="Form_hint is-error" data-id="form_error" role="alert" hidden></div>
-      <div id="form_warning" class="Form_hint is-warning" data-id="form_warning" role="alert" hidden></div>
+      <div class="Form_messages" data-id="alert_messages"></div>
 
       <div class="Form_coverage" data-id="form_coverage" hidden>
         <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>

--- a/client/view/Alert/Alert.css
+++ b/client/view/Alert/Alert.css
@@ -1,0 +1,24 @@
+.Alert {
+  padding: 12px 14px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--text-primary);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &.is-error {
+    background: var(--error);
+  }
+
+  &.is-warning {
+    background: var(--warning);
+  }
+}
+
+.Alert a {
+  color: inherit;
+}

--- a/client/view/Alert/Alert.js
+++ b/client/view/Alert/Alert.js
@@ -1,0 +1,32 @@
+import { createTag } from '../../lib/utils'
+import { onFormSubmit } from '../Form/Form'
+
+let alertMessages = document.querySelector('[data-id=alert_messages]')
+
+let formatText = text => `${text.replace(/`([^`]+)`/g, '<strong>$1</strong>')}`
+
+export function showError(message, textarea) {
+  let error = createTag('div', ['Alert', 'is-error'])
+  error.innerHTML = formatText(message)
+  error.role = 'alert'
+  alertMessages.appendChild(error)
+
+  textarea.setAttribute('aria-errormessage', 'form_error')
+  textarea.setAttribute('aria-invalid', 'true')
+
+  onFormSubmit(() => {
+    textarea.removeAttribute('aria-errormessage')
+    textarea.removeAttribute('aria-invalid')
+    error.remove()
+  })
+}
+
+export function showWarning(message) {
+  let warning = createTag('div', ['Alert', 'is-warning'])
+  warning.innerHTML = formatText(message)
+  alertMessages.appendChild(warning)
+
+  onFormSubmit(() => {
+    warning.remove()
+  })
+}

--- a/client/view/Base/colors.css
+++ b/client/view/Base/colors.css
@@ -12,8 +12,8 @@
   --text-underline-hover: oklch(23% 0 0);
   --accent-alternave: oklch(88% 0.16 92);
   --separator: oklch(23% 0 0 / 12%);
-  --warning: oklch(73% 0.16 66 / 80%);
-  --error: oklch(66% 0.1 30);
+  --warning: oklch(93.97% 0.094 94.62);
+  --error: oklch(70.31% 0.182 51.51 / 14%);
   --twitter: oklch(70% 0.12 235);
 }
 
@@ -32,6 +32,7 @@
     --text-underline-hover: oklch(100% 0 0 / 85%);
     --accent-alternave: oklch(63% 0.13 79);
     --separator: oklch(100% 0 0 / 20%);
-    --warning: oklch(48% 0.1 66);
+    --warning: oklch(75.99% 0.147 83.09 / 20%);
+    --error: oklch(66.29% 0.227 35.97 / 20%);
   }
 }

--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -49,36 +49,12 @@
   pointer-events: none;
 }
 
-.Form_hint {
-  padding: 12px 14px;
-  margin: -16px 0 8px;
-  border-radius: 8px;
-  font-weight: 400;
-  color: var(--text-primary);
+.Form_messages {
+  margin-top: -16px;
 
-  &.is-error {
-    background: var(--error);
+  &:empty {
+    display: none;
   }
-
-  &.is-warning {
-    background: var(--warning);
-  }
-}
-
-.Form_hint p {
-  font-size: 14px;
-  line-height: 18px;
-  letter-spacing: initial;
-  margin-top: 0;
-  margin-bottom: 8px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.Form_hint a {
-  color: inherit;
 }
 
 .Form_placeholder {

--- a/client/view/Form/Form.css
+++ b/client/view/Form/Form.css
@@ -32,7 +32,6 @@
   outline-color: var(--accent);
 }
 
-.Form_hint,
 .Form_loader {
   position: absolute;
   bottom: 16px;
@@ -47,23 +46,39 @@
   background-color: var(--main-bg);
   opacity: 0%;
   transition: opacity 0.2s linear;
-}
-
-.Form_loader {
   pointer-events: none;
 }
 
-.Form_hint.is-error {
-  color: var(--error);
+.Form_hint {
+  padding: 12px 14px;
+  margin: -16px 0 8px;
+  border-radius: 8px;
+  font-weight: 400;
+  color: var(--text-primary);
+
+  &.is-error {
+    background: var(--error);
+  }
+
+  &.is-warning {
+    background: var(--warning);
+  }
 }
 
-.Form_hint.is-warning {
-  color: var(--warning);
+.Form_hint p {
+  font-size: 14px;
+  line-height: 18px;
+  letter-spacing: initial;
+  margin-top: 0;
+  margin-bottom: 8px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .Form_hint a {
   color: inherit;
-  pointer-events: initial;
 }
 
 .Form_placeholder {
@@ -77,14 +92,6 @@
   color: var(--text-secondary);
   pointer-events: none;
   opacity: 0%;
-}
-
-.Form.is-error:not(.is-loading) .Form_hint.is-error {
-  opacity: 100%;
-}
-
-.Form.is-warning:not(.is-loading) .Form_hint.is-warning {
-  opacity: 100%;
 }
 
 .Form_textarea:placeholder-shown ~ .Form_placeholder {

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -44,7 +44,7 @@ export function submitForm() {
 }
 
 function onNextChange(cb) {
-  textarea.addEventListener('input', cb, { once: true })
+  form.addEventListener('submit', cb, { once: true })
 }
 
 function renderError(message) {

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -31,8 +31,6 @@ function createOptgroup(groupName, regionsGroup) {
 
 export function setFormValues({ query, region }) {
   textarea.value = query
-  form.classList.remove('is-error')
-  form.classList.remove('is-warning')
 
   if (!region) region = 'alt-ww'
   let isRegionExists = regionList.includes(region)
@@ -51,25 +49,28 @@ function onNextChange(cb) {
 
 function renderError(message) {
   errorMessage.innerHTML = message
-  form.classList.add('is-error')
+  errorMessage.hidden = false
   textarea.setAttribute('aria-errormessage', 'form_error')
   textarea.setAttribute('aria-invalid', 'true')
   onNextChange(() => {
     textarea.removeAttribute('aria-errormessage')
     textarea.removeAttribute('aria-invalid')
     errorMessage.innerHTML = ''
-    form.classList.remove('is-error')
+    errorMessage.hidden = true
   })
 }
 
 function renderWarning(message) {
   warningMessage.innerHTML = message
-  form.classList.add('is-warning')
+  warningMessage.hidden = false
   onNextChange(() => {
     warningMessage.innerHTML = ''
-    form.classList.remove('is-warning')
+    warningMessage.hidden = true
   })
 }
+
+let formatHintText = text =>
+  `<p>${text.replace(/`([^`]+)`/g, '<strong>$1</strong>')}</p>`
 
 let prev = ''
 async function updateStatsView(query, region) {
@@ -89,7 +90,7 @@ async function updateStatsView(query, region) {
     data = await loadBrowsers(query, region)
   } catch (e) {
     if (e.name === 'ServerError') {
-      renderError(e.message)
+      renderError(formatHintText(e.message))
     } else {
       throw e
     }
@@ -105,10 +106,8 @@ async function updateStatsView(query, region) {
 
   if (lint.length > 0) {
     let linterWarning = lint
-      .map(({ message }) =>
-        message.replace(/`([^`]+)`/g, '<strong>$1</strong>')
-      )
-      .join('.<br />')
+      .map(({ message }) => formatHintText(message + '.'))
+      .join('')
     renderWarning(linterWarning)
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22644149/188993367-b21b8114-5f2f-4d02-abc4-a22acb5dc4bd.png)


- [x] I used better design for warnings (Closes #457)
   - [x] Light theme
   - [x] Dark theme (tomorrow designers to approve or suggests better colors)
- [x] Replaced quote symbols \`query\` in errors to `<strong>query</strong>` like a warnings
- [x] Improved multiple lint messages output. I used `<p>...</p> <p>...</p>` instead `<br>`

**Refactoring**
- [x] Removed  unused `.Form.is-error` and `.Form.is-warning` that used for animations. And I didn't animate `max-height` or `padding-top/bottom` that trigger layout recalculation and cause strange layout shifts.