### PR TITLE
Fix components composition

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -53,7 +53,7 @@
         <p class="Form_loader">Loading…</p>
       </div>
 
-      <div class="Form_messages" data-id="alert_messages"></div>
+      <div class="Form_messages" data-id="form_messages"></div>
 
       <div class="Form_coverage" data-id="form_coverage" hidden>
         <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>

--- a/client/view/Alert/Alert.js
+++ b/client/view/Alert/Alert.js
@@ -1,32 +1,20 @@
 import { createTag } from '../../lib/utils'
-import { onFormSubmit } from '../Form/Form'
 
-let alertMessages = document.querySelector('[data-id=alert_messages]')
+function formatText(text) {
+  return `${text.replace(/`([^`]+)`/g, '<strong>$1</strong>')}`
+}
 
-let formatText = text => `${text.replace(/`([^`]+)`/g, '<strong>$1</strong>')}`
-
-export function showError(message, textarea) {
+export function buildError(root, message) {
   let error = createTag('div', ['Alert', 'is-error'])
   error.innerHTML = formatText(message)
   error.role = 'alert'
-  alertMessages.appendChild(error)
-
-  textarea.setAttribute('aria-errormessage', 'form_error')
-  textarea.setAttribute('aria-invalid', 'true')
-
-  onFormSubmit(() => {
-    textarea.removeAttribute('aria-errormessage')
-    textarea.removeAttribute('aria-invalid')
-    error.remove()
-  })
+  root.appendChild(error)
+  return error
 }
 
-export function showWarning(message) {
+export function buildWarning(root, message) {
   let warning = createTag('div', ['Alert', 'is-warning'])
   warning.innerHTML = formatText(message)
-  alertMessages.appendChild(warning)
-
-  onFormSubmit(() => {
-    warning.remove()
-  })
+  root.appendChild(warning)
+  return warning
 }

--- a/client/view/Base/colors.css
+++ b/client/view/Base/colors.css
@@ -12,8 +12,8 @@
   --text-underline-hover: oklch(23% 0 0);
   --accent-alternave: oklch(88% 0.16 92);
   --separator: oklch(23% 0 0 / 12%);
-  --warning: oklch(93.97% 0.094 94.62);
-  --error: oklch(70.31% 0.182 51.51 / 14%);
+  --warning: oklch(94% 0.09 95);
+  --error: oklch(82% 0.09 20);
   --twitter: oklch(70% 0.12 235);
 }
 
@@ -32,7 +32,7 @@
     --text-underline-hover: oklch(100% 0 0 / 85%);
     --accent-alternave: oklch(63% 0.13 79);
     --separator: oklch(100% 0 0 / 20%);
-    --warning: oklch(75.99% 0.147 83.09 / 20%);
-    --error: oklch(66.29% 0.227 35.97 / 20%);
+    --warning: oklch(76% 0.15 83 / 20%);
+    --error: oklch(76% 0.14 20 / 20%);
   }
 }

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -2,11 +2,11 @@ import { DEFAULT_REGION, regionList, regionGroups } from '../../data/regions.js'
 import { updateBrowsersStats, toggleBrowsers } from '../Browsers/Browsers.js'
 import { debounce, formatPercent, createTag } from '../../lib/utils.js'
 import { updateQueryLinksRegion } from '../QueryLink/QueryLink.js'
+import { buildError, buildWarning } from '../Alert/Alert.js'
 import { toggleHedgehog } from '../Hedgehog/Hedgehog.js'
 import { updateVersions } from '../Versions/Versions.js'
 import { transformQuery } from './transformQuery.js'
 import { loadBrowsers } from './loadBrowsers.js'
-import { showError, showWarning } from '../Alert/Alert.js'
 import { updateBar } from '../Bar/Bar.js'
 
 let form = document.querySelector('[data-id=form]')
@@ -14,6 +14,7 @@ let total = document.querySelector('[data-id=form_total]')
 let formCoverage = document.querySelector('[data-id=form_coverage')
 let textarea = document.querySelector('[data-id=form_textarea]')
 let regionSelect = document.querySelector('[data-id=form_region]')
+let messages = document.querySelector('[data-id=form_messages]')
 
 function createOptgroup(groupName, regionsGroup) {
   let optgroup = createTag('optgroup')
@@ -40,10 +41,6 @@ export function setFormValues({ query, region }) {
 
 export function submitForm() {
   form.dispatchEvent(new Event('submit', { cancelable: true }))
-}
-
-export function onFormSubmit(cb) {
-  form.addEventListener('submit', cb, { once: true })
 }
 
 let prev = ''
@@ -116,6 +113,32 @@ function submitFormWithUrlParams() {
 
 export function focusForm() {
   textarea.focus()
+}
+
+export function showError(message) {
+  let error = buildError(messages, message)
+  textarea.setAttribute('aria-errormessage', 'form_error')
+  textarea.setAttribute('aria-invalid', 'true')
+  form.addEventListener(
+    'submit',
+    () => {
+      textarea.removeAttribute('aria-errormessage')
+      textarea.removeAttribute('aria-invalid')
+      error.remove()
+    },
+    { once: true }
+  )
+}
+
+export function showWarning(message) {
+  let warning = buildWarning(messages, message)
+  form.addEventListener(
+    'submit',
+    () => {
+      warning.remove()
+    },
+    { once: true }
+  )
 }
 
 regionSelect.appendChild(createOptgroup('Continents', regionGroups.continents))


### PR DESCRIPTION
There were a few problems of components separation in https://github.com/browserslist/browsersl.ist/pull/482

- `Form_messages` was styles in one component, but JS was added in another
- `Alert` knew too many things about `Form`. For instance, alert works with form’s `textarea` directly.

This PR split logic between component in a more gentle way. Yes, we have a problem with huge Form component.

I also changed error color, so it is more red-ish and closer to warning’s yellow in terms of chroma.

![Снимок экрана от 2022-09-09 11-50-33](https://user-images.githubusercontent.com/19343/189323092-37955746-8fb2-4e69-8039-47c9bf080aa3.png)
