### PR TITLE
Fix bar opacity

### DIFF
--- a/client/view/Bar/Bar.js
+++ b/client/view/Bar/Bar.js
@@ -1,12 +1,13 @@
+import { createTag } from '../../lib/utils.js'
+
 let bar = document.querySelector('[data-id=bar]')
 
 export function updateBar(data) {
   bar.replaceChildren(
     ...data.map(item => {
-      let el = document.createElement('li')
       let alpha = (100 - 100 / item.coverage) / 100
       if (alpha < 0.3) alpha = 0.3
-      el.classList.add('Bar_item')
+      let el = createTag('li', ['Bar_item'])
       el.style.setProperty('--proportion', item.coverage)
       el.style.setProperty('--alpha', alpha)
       if (item.coverage > 10) {

--- a/client/view/Bar/Bar.js
+++ b/client/view/Bar/Bar.js
@@ -4,9 +4,11 @@ export function updateBar(data) {
   bar.replaceChildren(
     ...data.map(item => {
       let el = document.createElement('li')
+      let alpha = (100 - 100 / item.coverage) / 100
+      if (alpha < 0.3) alpha = 0.3
       el.classList.add('Bar_item')
       el.style.setProperty('--proportion', item.coverage)
-      el.style.setProperty('--alpha', 1 - 1 / item.coverage)
+      el.style.setProperty('--alpha', alpha)
       if (item.coverage > 10) {
         el.innerText = item.name
         el.classList.add('is-texted')


### PR DESCRIPTION
Now, not-popular browsers has negative opacity. As the result, the visible part of the bar is smaller.

Before:
![Снимок экрана от 2022-09-18 14-02-46](https://user-images.githubusercontent.com/19343/190901082-9fb00024-7c56-41c6-a824-ae8afe4b0fa3.png)

After:
![Снимок экрана от 2022-09-18 14-05-14](https://user-images.githubusercontent.com/19343/190901187-c44aa5b6-37ea-44eb-9d03-a194d0b3b3fb.png)
