### PR TITLE
Fix grammar in label of the last update timestamp

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -85,7 +85,7 @@
 
         <div class="Versions">
           <p class="Versions_item">
-            Updated at <strong class="Versions_date" data-id="versions_updated"></strong>
+            Updated on <strong class="Versions_date" data-id="versions_updated"></strong>
           </p>
           <p class="Versions_item">
             Browserslist <a class="Versions_link" target="_blank" href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md" data-id="versions_browserslist"></a>


### PR DESCRIPTION
I believe the timestamp should be `Updated on DATE at TIME`. And therefore only `on` for date-only timestamps.

* https://forum.wordreference.com/threads/updated-on-or-at-april-4-2018-13-00-03.3484362/post-17687092
* https://english.stackexchange.com/a/182663