### PR TITLE
Fix raw backticks

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -282,7 +282,7 @@
           <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
           or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
         </li>
-        <li>Note, that Opera Mini (extreme data saving mode) has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
+        <li>Note, that Opera Mini has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
       </ul>
 
       <details>

--- a/client/index.html
+++ b/client/index.html
@@ -282,7 +282,7 @@
           <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
           or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
         </li>
-        <li>Note, that Opera Mini has special version `all`. `not op_mini all` is not a special query.</li>
+        <li>Note, that Opera Mini (extreme data saving mode) has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
       </ul>
 
       <details>


### PR DESCRIPTION
Opera Mini seems to have 2 data saving modes:

- Extreme
- High

https://blogs.opera.com/news/2015/09/new-high-saving-data-opera-mini/

"High" seems to be compatible with Chrome.
[caniuse.com](caniuse.com) says "To test on iOS/Android this mode can be enabled using "Extreme data savings"".

In short, what we call `op_mini` is not the entire of Opera Mini but just one of its modes.