### PR TITLE
Fix bug on homepage where "Last 2 versions of Safari" link didn't work

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,439 +1,439 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="color-scheme" content="dark light">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Browserslist</title>
-    <meta name="description" content="Display target browsers from a Browserslist config">
-    <meta property="og:image" content="https://browsersl.ist/og.png">
-    <link rel="stylesheet" href="./index.css">
-    <script type="module" src="./index.js" defer></script>
-    <link rel="preload" href="./view/MartianMono/MartianMono-0.9.1.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" href="./view/Base/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="./view/Base/apple-touch-icon.png">
-    <link rel="manifest" href="/browserslist.webmanifest">
-  </head>
+<head>
+  <meta charset="UTF-8">
+  <meta name="color-scheme" content="dark light">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Browserslist</title>
+  <meta name="description" content="Display target browsers from a Browserslist config">
+  <meta property="og:image" content="https://browsersl.ist/og.png">
+  <link rel="stylesheet" href="./index.css">
+  <script type="module" src="./index.js" defer></script>
+  <link rel="preload" href="./view/MartianMono/MartianMono-0.9.1.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" href="./view/Base/icon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="./view/Base/apple-touch-icon.png">
+  <link rel="manifest" href="/browserslist.webmanifest">
+</head>
 
-  <body>
-    <header class="Intro">
-      <button class="Skip" data-id="skip">Skip to form</button>
-      <div class="Intro_header">
-        <h1 class="Intro_title">
-          <img class="Intro_logo" src="./view/Intro/browserlist.svg" alt="">
-          Browserslist
-        </h1>
-        <a class="Badge is-github" href="https://github.com/browserslist/browserslist" target="_blank">
-          <img src="./view/Badge/github.svg" alt="Count of GitHub stars" class="Badge_logo"> 11K
-        </a>
-        <a class="Badge" href="https://twitter.com/Browserslist"  target="_blank">
-          <img src="./view/Badge/twitter.svg" alt="Count of Twitter followers" class="Badge_logo"> 1728
-        </a>
-      </div>
-      <p class="Intro_about">Shared browser compatibility config for popular JavaScript tools
-        like Autoprefixer, Babel, ESLint, PostCSS, and Webpack
-      </p>
-      <p class="Intro_supported">
-        Supported by
-        <a href="https://evilmartians.com/" class="Link is-image" target="_blank"><img class="Intro_martians" src="./view/Intro/evil_maritians.svg" alt=""> <span class="Link_text">Evil Martians</span></a> and
-        <a href="https://cube.dev/?ref=eco-browserslist" class="Link is-image" target="_blank"><img class="Intro_cube" src="./view/Intro/cube.svg" alt=""> <span class="Link_text">Cube</span></a>
-      </p>
-    </header>
-    
-    <main class="Interactive" data-id="interactive">
-      <h2 class="Interactive_title">Check compatible browsers</h2>
-      <form data-id="form" class="Form">
-        <div class="Form_query">
-          <textarea id="form_query" name="query" cols="30" rows="5" required class="Form_textarea" data-id="form_textarea" placeholder="Write the Browserslist config here…"></textarea>
-          <label for="form_query" class="Form_placeholder">Write the Browserslist config here…<br>
-            For example
-            <a class="QueryLink"><code>defaults</code></a>,
-            <a class="QueryLink"><code>> 0.2% and not dead</code></a>
-          </label>
-          <p class="Form_loader">Loading…</p>
-        </div>
-
-        <div class="Form_messages" data-id="form_messages"></div>
-
-        <div class="Form_coverage" data-id="form_coverage" hidden>
-          <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>
-          <label class="Form_region">
-            Region
-            <select name="region" data-id="form_region" class="Form_select"></select>
-          </label>
-        </div>
-      </form>
-
-      <div class="Hedgehog" data-id="hedgehog">
-        <img
-          srcset="./view/Hedgehog/hedgehog.svg"
-          alt="A hedgehog with a wheelbarrow full of browser logos. He brings them to you!"
-          class="Hedgehog_image"
-          height="316px"
-          width="380px"
-          >
-        <p class="Hedgehog_text">Add the Browserslist config to display compatible browsers.</p>
-      </div>
-
-      <div class="Browsers" data-id="browsers" hidden>
-        <div class="Browsers_scroll">
-          <ul class="Bar" data-id="bar"></ul>
-          <div class="Browsers_results">
-            <table class="Browsers_table" data-id="browsers_table">
-            </table>
-          </div>
-
-          <div class="Versions">
-            <p class="Versions_item">
-              Updated on <strong class="Versions_date" data-id="versions_updated"></strong>
-            </p>
-            <p class="Versions_item">
-              Browserslist <a class="Versions_link" target="_blank" href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md" data-id="versions_browserslist"></a>
-            </p>
-            <p class="Versions_item">
-              Can I Use <a class="Versions_link" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="versions_caniuse"></a>
-            </p>
-          </div>
-        </div>
-      </div>
-    </main>
-
-    <article class="Docs">
-      <h2>How to get started</h2>
-      <p>
-        Use <a class="QueryLink"><code>defaults</code></a> if you're building a web application for
-        the global audience.
-      </p>
-      <p>
-        Use <a class="QueryLink"><code>node 18</code></a> if you're building a Node.js application,
-        e.g., for server-side rendering.
-      </p>
-      <p>
-        <a href="https://www.npmjs.com/package/autoprefixer" class="Link" target="_blank">Autoprefixer</a>,
-        <a href="https://babeljs.io/" class="Link" target="_blank">Babel</a> and
-        <a href="https://github.com/browserslist/browserslist#browserslist-" class="Link" target="_blank">many other tools</a>
-        will find target browsers automatically if you add the following to <b>package.json</b>:
-      </p>
-      <a class="QueryLink is-pre">
-        <pre>
-          <code>"browserslist": [</code>
-          <code>  "defaults and supports es6-module",</code>
-          <code>  "maintained node versions"</code>
-          <code>]</code>
-        </pre>
+<body>
+  <header class="Intro">
+    <button class="Skip" data-id="skip">Skip to form</button>
+    <div class="Intro_header">
+      <h1 class="Intro_title">
+        <img class="Intro_logo" src="./view/Intro/browserlist.svg" alt="">
+        Browserslist
+      </h1>
+      <a class="Badge is-github" href="https://github.com/browserslist/browserslist" target="_blank">
+        <img src="./view/Badge/github.svg" alt="Count of GitHub stars" class="Badge_logo"> 11K
       </a>
-      <h2>Query syntax</h2>
-      <section>
-        <h3>Start with the default configuration</h3>
-        <p>You can pick a sound set of versions with the <a class="QueryLink"><code>defaults</code></a> query which is
-          a shortcut for <code>> 0.5%, last 2 versions, Firefox ESR, not dead</code>.
-          It matches recent versions of popular and supported browsers worldwide and includes
-          Firefox Extended Support Release which is updated roughly annually.
-        </p>
-        <p>The <a class="QueryLink"><code>defaults</code></a> query was thoroughly designed by the
-          Browserslist community.
-          It helps promote best practices and avoid common pitfalls.
-        </p>
-      </section>
+      <a class="Badge" href="https://twitter.com/Browserslist"  target="_blank">
+        <img src="./view/Badge/twitter.svg" alt="Count of Twitter followers" class="Badge_logo"> 1728
+      </a>
+    </div>
+    <p class="Intro_about">Shared browser compatibility config for popular JavaScript tools
+      like Autoprefixer, Babel, ESLint, PostCSS, and Webpack
+    </p>
+    <p class="Intro_supported">
+      Supported by
+      <a href="https://evilmartians.com/" class="Link is-image" target="_blank"><img class="Intro_martians" src="./view/Intro/evil_maritians.svg" alt=""> <span class="Link_text">Evil Martians</span></a> and
+      <a href="https://cube.dev/?ref=eco-browserslist" class="Link is-image" target="_blank"><img class="Intro_cube" src="./view/Intro/cube.svg" alt=""> <span class="Link_text">Cube</span></a>
+    </p>
+  </header>
+  
+  <main class="Interactive" data-id="interactive">
+    <h2 class="Interactive_title">Check compatible browsers</h2>
+    <form data-id="form" class="Form">
+      <div class="Form_query">
+        <textarea id="form_query" name="query" cols="30" rows="5" required class="Form_textarea" data-id="form_textarea" placeholder="Write the Browserslist config here…"></textarea>
+        <label for="form_query" class="Form_placeholder">Write the Browserslist config here…<br>
+          For example
+          <a class="QueryLink"><code>defaults</code></a>,
+          <a class="QueryLink"><code>> 0.2% and not dead</code></a>
+        </label>
+        <p class="Form_loader">Loading…</p>
+      </div>
 
-      <section>
-        <h3>Select browser versions with certain usage</h3>
-        <p>You can pick versions that have more than or less than a certain size of the
-          audience worldwide, in a region, or in a country. You can also use the visitor
-          data of your own website.
-        </p>
-        <h4>Examples</h4>
-        <ul>
-          <li><a class="QueryLink"><code>> 5%</code></a> all versions with > 5% of the audience
-            worldwide.
-          </li>
-          <li><a class="QueryLink"><code>>= 5% in US</code></a> same as above but in the US.
-          </li>
-          <li><a class="QueryLink"><code>>= 5% in alt-AS</code></a> same as above but in Asia.
-          </li>
-        </ul>
-        <h4>Beware</h4>
-        <ul>
-          <li> You may exclude the most recent versions of all browsers that have been just
-            released. Please always add <a class="QueryLink" data-query="last 2 versions"><code>last …
-            versions</code></a> to include them back.
-          </li>
-          <li> You can exclude your global audience. Please be careful when narrowing the audience to a region or a country.
-          </li>
-          <li> You may include <a class="QueryLink"><code>dead</code></a> versions. Please consider
-            adding <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
-          </li>
-        </ul>
-        
-        <details>
-          <summary>
-            <h4>Advanced</h4>
-          </summary>
-          <ul>
-            <li><a class="QueryLink"><code>> 5% in my stats</code></a> versions with >
-              5%
-              of usage
-              within your own audience.
-            </li>
-            <li><a class="QueryLink"><code>> 5% in circle-ci stats</code></a>
-              versions with > 5% of usage within the audience data from shareable configuration, available as <a
-                href="https://github.com/circleci/circleci-docs/blob/master/browserslist-stats.json" class="Link"
-                target="_blank">custom stats</a>.
-            </li>
-            <li><a class="QueryLink"><code>cover 99.5%</code></a> the smallest set of popular
-              versions with collective usage over 99.5% of the audience worldwide.
-            </li>
-            <li><a class="QueryLink"><code>cover 99.5% in CN</code></a> same as above
-              but in China.
-            </li>
-            <li><a class="QueryLink"><code>cover 99.5% in alt-EU</code></a> same
-              as above but in Europe.
-            </li>
-          </ul>
-        </details>
-      </section>
+      <div class="Form_messages" data-id="form_messages"></div>
+
+      <div class="Form_coverage" data-id="form_coverage" hidden>
+        <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>
+        <label class="Form_region">
+          Region
+          <select name="region" data-id="form_region" class="Form_select"></select>
+        </label>
+      </div>
+    </form>
+
+    <div class="Hedgehog" data-id="hedgehog">
+      <img
+        srcset="./view/Hedgehog/hedgehog.svg"
+        alt="A hedgehog with a wheelbarrow full of browser logos. He brings them to you!"
+        class="Hedgehog_image"
+        height="316px"
+        width="380px"
+        >
+      <p class="Hedgehog_text">Add the Browserslist config to display compatible browsers.</p>
+    </div>
+
+    <div class="Browsers" data-id="browsers" hidden>
+      <div class="Browsers_scroll">
+        <ul class="Bar" data-id="bar"></ul>
+        <div class="Browsers_results">
+          <table class="Browsers_table" data-id="browsers_table">
+          </table>
+        </div>
+
+        <div class="Versions">
+          <p class="Versions_item">
+            Updated on <strong class="Versions_date" data-id="versions_updated"></strong>
+          </p>
+          <p class="Versions_item">
+            Browserslist <a class="Versions_link" target="_blank" href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md" data-id="versions_browserslist"></a>
+          </p>
+          <p class="Versions_item">
+            Can I Use <a class="Versions_link" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="versions_caniuse"></a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <article class="Docs">
+    <h2>How to get started</h2>
+    <p>
+      Use <a class="QueryLink"><code>defaults</code></a> if you're building a web application for
+      the global audience.
+    </p>
+    <p>
+      Use <a class="QueryLink"><code>node 18</code></a> if you're building a Node.js application,
+      e.g., for server-side rendering.
+    </p>
+    <p>
+      <a href="https://www.npmjs.com/package/autoprefixer" class="Link" target="_blank">Autoprefixer</a>,
+      <a href="https://babeljs.io/" class="Link" target="_blank">Babel</a> and
+      <a href="https://github.com/browserslist/browserslist#browserslist-" class="Link" target="_blank">many other tools</a>
+      will find target browsers automatically if you add the following to <b>package.json</b>:
+    </p>
+    <a class="QueryLink is-pre">
+      <pre>
+        <code>"browserslist": [</code>
+        <code>  "defaults and supports es6-module",</code>
+        <code>  "maintained node versions"</code>
+        <code>]</code>
+      </pre>
+    </a>
+    <h2>Query syntax</h2>
+    <section>
+      <h3>Start with the default configuration</h3>
+      <p>You can pick a sound set of versions with the <a class="QueryLink"><code>defaults</code></a> query which is
+        a shortcut for <code>> 0.5%, last 2 versions, Firefox ESR, not dead</code>.
+        It matches recent versions of popular and supported browsers worldwide and includes
+        Firefox Extended Support Release which is updated roughly annually.
+      </p>
+      <p>The <a class="QueryLink"><code>defaults</code></a> query was thoroughly designed by the
+        Browserslist community.
+        It helps promote best practices and avoid common pitfalls.
+      </p>
+    </section>
+
+    <section>
+      <h3>Select browser versions with certain usage</h3>
+      <p>You can pick versions that have more than or less than a certain size of the
+        audience worldwide, in a region, or in a country. You can also use the visitor
+        data of your own website.
+      </p>
+      <h4>Examples</h4>
+      <ul>
+        <li><a class="QueryLink"><code>> 5%</code></a> all versions with > 5% of the audience
+          worldwide.
+        </li>
+        <li><a class="QueryLink"><code>>= 5% in US</code></a> same as above but in the US.
+        </li>
+        <li><a class="QueryLink"><code>>= 5% in alt-AS</code></a> same as above but in Asia.
+        </li>
+      </ul>
+      <h4>Beware</h4>
+      <ul>
+        <li> You may exclude the most recent versions of all browsers that have been just
+          released. Please always add <a class="QueryLink" data-query="last 2 versions"><code>last …
+          versions</code></a> to include them back.
+        </li>
+        <li> You can exclude your global audience. Please be careful when narrowing the audience to a region or a country.
+        </li>
+        <li> You may include <a class="QueryLink"><code>dead</code></a> versions. Please consider
+          adding <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
+        </li>
+      </ul>
       
-      <section>
-        <h3>Select recent browser versions</h3>
-        <p>You can pick a few recent browser versions.</p>
-        <h4>Examples</h4>
+      <details>
+        <summary>
+          <h4>Advanced</h4>
+        </summary>
         <ul>
-          <li><a class="QueryLink"><code>last 2 versions</code></a> last 2 versions of each
-            browser.
+          <li><a class="QueryLink"><code>> 5% in my stats</code></a> versions with >
+            5%
+            of usage
+            within your own audience.
           </li>
-          <li><a class="QueryLink"><code>last 2 Chrome versions</code></a> same as above but just
-            Chrome.
+          <li><a class="QueryLink"><code>> 5% in circle-ci stats</code></a>
+            versions with > 5% of usage within the audience data from shareable configuration, available as <a
+              href="https://github.com/circleci/circleci-docs/blob/master/browserslist-stats.json" class="Link"
+              target="_blank">custom stats</a>.
+          </li>
+          <li><a class="QueryLink"><code>cover 99.5%</code></a> the smallest set of popular
+            versions with collective usage over 99.5% of the audience worldwide.
+          </li>
+          <li><a class="QueryLink"><code>cover 99.5% in CN</code></a> same as above
+            but in China.
+          </li>
+          <li><a class="QueryLink"><code>cover 99.5% in alt-EU</code></a> same
+            as above but in Europe.
           </li>
         </ul>
-        
-        <h4>Beware</h4>
+      </details>
+    </section>
+    
+    <section>
+      <h3>Select recent browser versions</h3>
+      <p>You can pick a few recent browser versions.</p>
+      <h4>Examples</h4>
+      <ul>
+        <li><a class="QueryLink"><code>last 2 versions</code></a> last 2 versions of each
+          browser.
+        </li>
+        <li><a class="QueryLink"><code>last 2 Chrome versions</code></a> same as above but just
+          Chrome.
+        </li>
+      </ul>
+      
+      <h4>Beware</h4>
+      <ul>
+        <li>You might exclude older versions still used by a substantial audience.
+          Please always add <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include them back.
+        </li>
+        <li>You may pick <a class="QueryLink"><code>dead</code></a> browsers like Internet Explorer.
+          Always use <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
+          with <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
+        </li>
+      </ul>
+      
+      <details>
+        <summary>
+          <h4>Advanced</h4>
+        </summary>
         <ul>
-          <li>You might exclude older versions still used by a substantial audience.
-            Please always add <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include them back.
+          <li><a class="QueryLink"><code>last 2 major versions</code></a>
+            all minor and patch releases of the last 2 major versions.
           </li>
-          <li>You may pick <a class="QueryLink"><code>dead</code></a> browsers like Internet Explorer.
-            Always use <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
-            with <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
+          <li><a class="QueryLink"><code>last 2 Safari major versions</code></a>
+            same as above but just Safari.
+          </li>
+          <li><a class="QueryLink"><code>unreleased versions</code></a>
+            alpha and beta versions.
+          </li>
+          <li><a class="QueryLink"><code>unreleased Chrome versions</code></a>
+            same as above but just Chrome.
+          </li>
+          <li><a class="QueryLink"><code>since 2020-01-15</code></a>
+            versions released since Jan 15, 2020.
+          </li>
+          <li><a class="QueryLink"><code>since 2020-01</code></a>
+            versions released since January 2020, inclusive.
+          </li>
+          <li><a class="QueryLink"><code>since 2020</code></a>
+            versions released since 2020, inclusive.
+          </li>
+          <li><a class="QueryLink"><code>last 3 years</code></a>
+            same as above if you run this query in 2022.
           </li>
         </ul>
-        
-        <details>
-          <summary>
-            <h4>Advanced</h4>
-          </summary>
-          <ul>
-            <li><a class="QueryLink"><code>last 2 major versions</code></a>
-              all minor and patch releases of the last 2 major versions.
-            </li>
-            <li><a class="QueryLink"><code>last 2 Safari major versions</code></a>
-              same as above but just Safari.
-            </li>
-            <li><a class="QueryLink"><code>unreleased versions</code></a>
-              alpha and beta versions.
-            </li>
-            <li><a class="QueryLink"><code>unreleased Chrome versions</code></a>
-              same as above but just Chrome.
-            </li>
-            <li><a class="QueryLink"><code>since 2020-01-15</code></a>
-              versions released since Jan 15, 2020.
-            </li>
-            <li><a class="QueryLink"><code>since 2020-01</code></a>
-              versions released since January 2020, inclusive.
-            </li>
-            <li><a class="QueryLink"><code>since 2020</code></a>
-              versions released since 2020, inclusive.
-            </li>
-            <li><a class="QueryLink"><code>last 3 years</code></a>
-              same as above if you run this query in 2022.
-            </li>
-          </ul>
-        </details>
-      </section>
+      </details>
+    </section>
 
-      <section>
-        <h3>Select specific browser versions</h3>
-        <p>You can pick browser versions or a version range of your choice.</p>
-        <h4>Examples</h4>
+    <section>
+      <h3>Select specific browser versions</h3>
+      <p>You can pick browser versions or a version range of your choice.</p>
+      <h4>Examples</h4>
+      <ul>
+        <li><a class="QueryLink"><code>ChromeAndroid 103</code></a> mobile Chrome
+          version 103.
+        </li>
+        <li><a class="QueryLink"><code>Firefox > 20</code></a> desktop Firefox versions
+          newer than 20.
+        </li>
+        <li><a class="QueryLink"><code>iOS >= 13.2</code></a> mobile Safari version 13.2
+          and
+          newer.
+        </li>
+        <li><a class="QueryLink" data-query="defaults, not firefox esr"><code>not Firefox ESR</code></a> removes specific version.
+        </li>
+      </ul>
+      <h4>Beware</h4>
+      <ul>
+        <li> Make sure that your audience uses specific versions (e.g., in a corporate
+          setting) or that your application is not built to work with specific
+          versions (e.g., it's a bleeding-edge demo project). Please consider using
+          <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
+          or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
+        </li>
+        <li>Note, that Opera Mini has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
+      </ul>
+
+      <details>
+        <summary>
+          <h4>Advanced</h4>
+        </summary>
         <ul>
-          <li><a class="QueryLink"><code>ChromeAndroid 103</code></a> mobile Chrome
-            version 103.
+          <li><a class="QueryLink"><code>ie 6-8</code></a> an inclusive range of Internet
+            Explorer
+            versions.
           </li>
-          <li><a class="QueryLink"><code>Firefox > 20</code></a> desktop Firefox versions
-            newer than 20.
-          </li>
-          <li><a class="QueryLink"><code>iOS >= 13.2</code></a> mobile Safari version 13.2
-            and
-            newer.
-          </li>
-          <li><a class="QueryLink" data-query="defaults, not firefox esr"><code>not Firefox ESR</code></a> removes specific version.
+          <li><a class="QueryLink"><code>Firefox ESR</code></a> the latest Firefox Extended
+            Support Release.
           </li>
         </ul>
-        <h4>Beware</h4>
-        <ul>
-          <li> Make sure that your audience uses specific versions (e.g., in a corporate
-            setting) or that your application is not built to work with specific
-            versions (e.g., it's a bleeding-edge demo project). Please consider using
-            <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
-            or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
-          </li>
-          <li>Note, that Opera Mini has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
-        </ul>
+      </details>
+    </section>
 
-        <details>
-          <summary>
-            <h4>Advanced</h4>
-          </summary>
-          <ul>
-            <li><a class="QueryLink"><code>ie 6-8</code></a> an inclusive range of Internet
-              Explorer
-              versions.
-            </li>
-            <li><a class="QueryLink"><code>Firefox ESR</code></a> the latest Firefox Extended
-              Support Release.
-            </li>
-          </ul>
-        </details>
-      </section>
+    <section>
+      <h3>Select specific Node.js versions</h3>
+      <p>You can pick Node.js versions or a version range of your choice. Useful if you
+        know for sure the runtime configuration of your server-side code.
+      </p>
+      <h4>Examples</h4>
+      <ul>
+        <li><a class="QueryLink"><code>node 10</code></a> latest
+          <a class="QueryLink" data-query="node 10.0.0"><code>10.x.x</code></a> Node.js version.
+        </li>
+        <li><a class="QueryLink"><code>node 10.4</code></a> latest
+          <a class="QueryLink" data-query="node 10.4.0"><code>10.4.x</code></a> Node.js version.
+        </li>
+        <li><a class="QueryLink"><code>node > 16</code></a> all Node.js versions newer than
+          <code>16.0.0</code>.
+        </li>
+        <li><a class="QueryLink"><code>last 2 node versions</code></a> two latest Node.js releases.
+        </li>
+        <li><a class="QueryLink"><code>last 2 node major versions</code></a> two last major-version Node.js releases.
+        </li>
+      </ul>
 
-      <section>
-        <h3>Select specific Node.js versions</h3>
-        <p>You can pick Node.js versions or a version range of your choice. Useful if you
-          know for sure the runtime configuration of your server-side code.
-        </p>
-        <h4>Examples</h4>
+      <details>
+        <summary>
+          <h4>Advanced</h4>
+        </summary>
         <ul>
-          <li><a class="QueryLink"><code>node 10</code></a> latest
-            <a class="QueryLink" data-query="node 10.0.0"><code>10.x.x</code></a> Node.js version.
+          <li><a class="QueryLink"><code>maintained node versions</code></a>
+            all Node.js versions currently maintained by Node.js Foundation.
           </li>
-          <li><a class="QueryLink"><code>node 10.4</code></a> latest
-            <a class="QueryLink" data-query="node 10.4.0"><code>10.4.x</code></a> Node.js version.
-          </li>
-          <li><a class="QueryLink"><code>node > 16</code></a> all Node.js versions newer than
-            <code>16.0.0</code>.
-          </li>
-          <li><a class="QueryLink"><code>last 2 node versions</code></a> two latest Node.js releases.
-          </li>
-          <li><a class="QueryLink"><code>last 2 node major versions</code></a> two last major-version Node.js releases.
+          <li><a class="QueryLink"><code>current node</code></a> the Node.js version used
+            by Browserslist right now.
           </li>
         </ul>
+      </details>
+    </section>
 
-        <details>
-          <summary>
-            <h4>Advanced</h4>
-          </summary>
-          <ul>
-            <li><a class="QueryLink"><code>maintained node versions</code></a>
-              all Node.js versions currently maintained by Node.js Foundation.
-            </li>
-            <li><a class="QueryLink"><code>current node</code></a> the Node.js version used
-              by Browserslist right now.
-            </li>
-          </ul>
-        </details>
-      </section>
+    <section>
+      <h3>Select browser versions that support a certain feature</h3>
+      <p>You can pick browser versions that fully support features from the Can I Use database. See the
+        <a href="https://github.com/browserslist/caniuse-lite/tree/main/data/features" class="Link" target="_blank">
+        caniuse-lite repository</a> for the full list of features.
+      </p>
+      <h4>Examples</h4>
+      <ul>
+        <li><a class="QueryLink"><code>supports es6-module</code></a> versions that support
+          JavaScript modules via script tag.
+        </li>
+        <li><a class="QueryLink"><code>supports css-grid</code></a> versions that support CSS Grid Layout.</li>
+      </ul>
+      <h4>Beware</h4>
+      <ul>
+        <li> This query rarely works well on its own. Please consider combining it with other queries.
+        </li>
+      </ul>
+    </section>
 
-      <section>
-        <h3>Select browser versions that support a certain feature</h3>
-        <p>You can pick browser versions that fully support features from the Can I Use database. See the
-          <a href="https://github.com/browserslist/caniuse-lite/tree/main/data/features" class="Link" target="_blank">
-          caniuse-lite repository</a> for the full list of features.
-        </p>
-        <h4>Examples</h4>
-        <ul>
-          <li><a class="QueryLink"><code>supports es6-module</code></a> versions that support
-            JavaScript modules via script tag.
-          </li>
-          <li><a class="QueryLink"><code>supports css-grid</code></a> versions that support CSS Grid Layout.</li>
-        </ul>
-        <h4>Beware</h4>
-        <ul>
-          <li> This query rarely works well on its own. Please consider combining it with other queries.
-          </li>
-        </ul>
-      </section>
+    <section>
+      <h3>Combine multiple queries into one</h3>
+      <p>You can combine versions matched by multiple queries with <code>or</code> or <code>,</code>; you can
+        intersect them with <code>and</code>. You can also negate any query with <code>not</code> if it's
+        not the first one in your list.
+      </p>
+      <h4>Examples</h4>
+      <ul>
+        <li>
+          <a class="QueryLink"><code>> 0.5%, last 2 versions</code></a>
+          combines <a class="QueryLink"><code>> 0.5%</code></a>
+          with <a class="QueryLink"><code>last 2 versions</code></a>.
+        </li>
+        <li><a class="QueryLink"><code>> 0.5% or last 2 versions</code></a>
+          same as above.
+        </li>
+        <li><a class="QueryLink"><code>> 0.5% and last 2 versions</code></a>
+          intersects <a class="QueryLink"><code>> 0.5%</code></a>
+          with <a class="QueryLink"><code>last 2 versions</code></a>.
+        </li>
+        <li><a class="QueryLink"><code>> 0.5% and not last 2 versions</code></a> removes
+          <a class="QueryLink"><code>last 2 versions</code></a> from
+          <a class="QueryLink"><code>> 0.5%</code></a>.
+        </li>
+      </ul>
 
-      <section>
-        <h3>Combine multiple queries into one</h3>
-        <p>You can combine versions matched by multiple queries with <code>or</code> or <code>,</code>; you can
-          intersect them with <code>and</code>. You can also negate any query with <code>not</code> if it's
-          not the first one in your list.
-        </p>
-        <h4>Examples</h4>
+      <h4>Beware</h4>
+      <ul>
+        <li> A query with <a class="QueryLink" data-query="defaults, not last 2 versions"><code>not</code></a>
+          can't be the left-hand one in the list.
+        </li>
+        <li> A query with <code>not</code> is always joined to the left-hand one with
+          <a class="QueryLink" data-query="defaults and not last 2 versions"><code>and</code></a>,
+          even if <a class="QueryLink" data-query="defaults or not last 2 versions"><code>or</code></a> or
+          <a class="QueryLink" data-query="defaults, not last 2 versions"><code>,</code></a> are used.
+        </li>
+      </ul>
+
+      <details>
+        <summary>
+          <h4>Advanced</h4>
+        </summary>
         <ul>
           <li>
-            <a class="QueryLink"><code>> 0.5%, last 2 versions</code></a>
-            combines <a class="QueryLink"><code>> 0.5%</code></a>
-            with <a class="QueryLink"><code>last 2 versions</code></a>.
-          </li>
-          <li><a class="QueryLink"><code>> 0.5% or last 2 versions</code></a>
-            same as above.
-          </li>
-          <li><a class="QueryLink"><code>> 0.5% and last 2 versions</code></a>
-            intersects <a class="QueryLink"><code>> 0.5%</code></a>
-            with <a class="QueryLink"><code>last 2 versions</code></a>.
-          </li>
-          <li><a class="QueryLink"><code>> 0.5% and not last 2 versions</code></a> removes
-            <a class="QueryLink"><code>last 2 versions</code></a> from
-            <a class="QueryLink"><code>> 0.5%</code></a>.
+            The following queries yield the same result:
+            <a class="QueryLink"> <code>> 0.5% and not last 2 versions</code></a>,
+            <a class="QueryLink"><code>> 0.5% or not last 2 versions</code></a>,
+            <a class="QueryLink"><code>> 0.5%, not last 2 versions</code></a>.
           </li>
         </ul>
+      </details>
+    </section>
 
-        <h4>Beware</h4>
-        <ul>
-          <li> A query with <a class="QueryLink" data-query="defaults, not last 2 versions"><code>not</code></a>
-            can't be the left-hand one in the list.
-          </li>
-          <li> A query with <code>not</code> is always joined to the left-hand one with
-            <a class="QueryLink" data-query="defaults and not last 2 versions"><code>and</code></a>,
-            even if <a class="QueryLink" data-query="defaults or not last 2 versions"><code>or</code></a> or
-            <a class="QueryLink" data-query="defaults, not last 2 versions"><code>,</code></a> are used.
-          </li>
-        </ul>
-
-        <details>
-          <summary>
-            <h4>Advanced</h4>
-          </summary>
-          <ul>
-            <li>
-              The following queries yield the same result:
-              <a class="QueryLink"> <code>> 0.5% and not last 2 versions</code></a>,
-              <a class="QueryLink"><code>> 0.5% or not last 2 versions</code></a>,
-              <a class="QueryLink"><code>> 0.5%, not last 2 versions</code></a>.
-            </li>
-          </ul>
-        </details>
-      </section>
-
-      <section>
-        <h3>Exclude unmaintained browser versions</h3>
-        <p>You can combine your queries with
-          <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>
-          to exclude <a class="QueryLink"><code>dead</code></a> browsers, i.e.,
-          browsers without official support or updates for more than 24 months.
-          Right now these include IE 11, IE Mobile 11, BlackBerry 10, BlackBerry 7,
-          Samsung 4, Opera Mobile 12.1, and all versions of Baidu.
-        </p>
-        <h4>Examples</h4>
-        <ul>
-          <li><a class="QueryLink"><code>> 0.2% and not dead</code></a>
-            excludes <a class="QueryLink"><code>dead</code></a> versions
-            from versions matched by <a class="QueryLink"><code>> 0.2%</code></a>.
-          </li>
-        </ul>
-      </section>
-
-      <h2>Why Browserslist</h2>
-      <p>Browserslist helps you keep the right balance between browser compatibility and bundle size.
-        With Browserslist, you will cover wider audience and have smaller bundle size. 
+    <section>
+      <h3>Exclude unmaintained browser versions</h3>
+      <p>You can combine your queries with
+        <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>
+        to exclude <a class="QueryLink"><code>dead</code></a> browsers, i.e.,
+        browsers without official support or updates for more than 24 months.
+        Right now these include IE 11, IE Mobile 11, BlackBerry 10, BlackBerry 7,
+        Samsung 4, Opera Mobile 12.1, and all versions of Baidu.
       </p>
-    </article>
+      <h4>Examples</h4>
+      <ul>
+        <li><a class="QueryLink"><code>> 0.2% and not dead</code></a>
+          excludes <a class="QueryLink"><code>dead</code></a> versions
+          from versions matched by <a class="QueryLink"><code>> 0.2%</code></a>.
+        </li>
+      </ul>
+    </section>
 
-    <footer class="Footer">
-      <a class="Badge is-github" href="https://github.com/browserslist/browsersl.ist" target="_blank">
-      <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
-      </a>
-    </footer>
-  </body>
+    <h2>Why Browserslist</h2>
+    <p>Browserslist helps you keep the right balance between browser compatibility and bundle size.
+      With Browserslist, you will cover wider audience and have smaller bundle size. 
+    </p>
+  </article>
+
+  <footer class="Footer">
+    <a class="Badge is-github" href="https://github.com/browserslist/browsersl.ist" target="_blank">
+    <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
+    </a>
+  </footer>
+</body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -1,440 +1,439 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="color-scheme" content="dark light">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Browserslist</title>
-  <meta name="description" content="Display target browsers from a Browserslist config">
-  <meta property="og:image" content="https://browsersl.ist/og.png">
-  <link rel="stylesheet" href="./index.css">
-  <script type="module" src="./index.js" defer></script>
-  <link rel="preload" href="./view/MartianMono/MartianMono-0.9.1.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="icon" href="/favicon.ico" sizes="any">
-  <link rel="icon" href="./view/Base/icon.svg" type="image/svg+xml">
-  <link rel="apple-touch-icon" href="./view/Base/apple-touch-icon.png">
-  <link rel="manifest" href="/browserslist.webmanifest">
-</head>
+   <head>
+      <meta charset="UTF-8">
+      <meta name="color-scheme" content="dark light">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <title>Browserslist</title>
+      <meta name="description" content="Display target browsers from a Browserslist config">
+      <meta property="og:image" content="https://browsersl.ist/og.png">
+      <link rel="stylesheet" href="./index.css">
+      <script type="module" src="./index.js" defer></script>
+      <link rel="preload" href="./view/MartianMono/MartianMono-0.9.1.woff2" as="font" type="font/woff2" crossorigin />
+      <link rel="icon" href="/favicon.ico" sizes="any">
+      <link rel="icon" href="./view/Base/icon.svg" type="image/svg+xml">
+      <link rel="apple-touch-icon" href="./view/Base/apple-touch-icon.png">
+      <link rel="manifest" href="/browserslist.webmanifest">
+   </head>
 
-<body>
-  <header class="Intro">
-    <button class="Skip" data-id="skip">Skip to form</button>
-    <div class="Intro_header">
-      <h1 class="Intro_title">
-        <img class="Intro_logo" src="./view/Intro/browserlist.svg" alt="">
-        Browserslist
-      </h1>
-      <a class="Badge is-github" href="https://github.com/browserslist/browserslist" target="_blank">
-        <img src="./view/Badge/github.svg" alt="Count of GitHub stars" class="Badge_logo"> 11K
-      </a>
-      <a class="Badge" href="https://twitter.com/Browserslist"  target="_blank">
-        <img src="./view/Badge/twitter.svg" alt="Count of Twitter followers" class="Badge_logo"> 1728
-      </a>
-    </div>
-    <p class="Intro_about">Shared browser compatibility config for popular JavaScript tools
-      like Autoprefixer, Babel, ESLint, PostCSS, and Webpack</p>
-    <p class="Intro_supported">
-      Supported by
-      <a href="https://evilmartians.com/" class="Link is-image" target="_blank"><img class="Intro_martians" src="./view/Intro/evil_maritians.svg" alt=""> <span class="Link_text">Evil Martians</span></a> and
-      <a href="https://cube.dev/?ref=eco-browserslist" class="Link is-image" target="_blank"><img class="Intro_cube" src="./view/Intro/cube.svg" alt=""> <span class="Link_text">Cube</span></a>
-    </p>
-  </header>
+   <body>
+      <header class="Intro">
+         <button class="Skip" data-id="skip">Skip to form</button>
+         <div class="Intro_header">
+            <h1 class="Intro_title">
+               <img class="Intro_logo" src="./view/Intro/browserlist.svg" alt="">
+               Browserslist
+            </h1>
+            <a class="Badge is-github" href="https://github.com/browserslist/browserslist" target="_blank">
+              <img src="./view/Badge/github.svg" alt="Count of GitHub stars" class="Badge_logo"> 11K
+            </a>
+            <a class="Badge" href="https://twitter.com/Browserslist"  target="_blank">
+              <img src="./view/Badge/twitter.svg" alt="Count of Twitter followers" class="Badge_logo"> 1728
+            </a>
+         </div>
+         <p class="Intro_about">Shared browser compatibility config for popular JavaScript tools
+            like Autoprefixer, Babel, ESLint, PostCSS, and Webpack
+         </p>
+         <p class="Intro_supported">
+            Supported by
+            <a href="https://evilmartians.com/" class="Link is-image" target="_blank"><img class="Intro_martians" src="./view/Intro/evil_maritians.svg" alt=""> <span class="Link_text">Evil Martians</span></a> and
+            <a href="https://cube.dev/?ref=eco-browserslist" class="Link is-image" target="_blank"><img class="Intro_cube" src="./view/Intro/cube.svg" alt=""> <span class="Link_text">Cube</span></a>
+         </p>
+      </header>
+      
+      <main class="Interactive" data-id="interactive">
+         <h2 class="Interactive_title">Check compatible browsers</h2>
+         <form data-id="form" class="Form">
+            <div class="Form_query">
+               <textarea id="form_query" name="query" cols="30" rows="5" required class="Form_textarea" data-id="form_textarea" placeholder="Write the Browserslist config here…"></textarea>
+               <label for="form_query" class="Form_placeholder">Write the Browserslist config here…<br>
+                 For example
+                 <a class="QueryLink"><code>defaults</code></a>,
+                 <a class="QueryLink"><code>> 0.2% and not dead</code></a>
+               </label>
+               <p class="Form_loader">Loading…</p>
+            </div>
 
-  <main class="Interactive" data-id="interactive">
-    <h2 class="Interactive_title">Check compatible browsers</h2>
-    <form data-id="form" class="Form">
-      <div class="Form_query">
-        <textarea id="form_query" name="query" cols="30" rows="5" required class="Form_textarea" data-id="form_textarea" placeholder="Write the Browserslist config here…"></textarea>
-        <label for="form_query" class="Form_placeholder">Write the Browserslist config here…<br>
-          For example
-          <a class="QueryLink"><code>defaults</code></a>,
-          <a class="QueryLink"><code>> 0.2% and not dead</code></a>
-        </label>
-        <p class="Form_loader">Loading…</p>
-      </div>
+            <div class="Form_messages" data-id="form_messages"></div>
 
-      <div class="Form_messages" data-id="form_messages"></div>
+            <div class="Form_coverage" data-id="form_coverage" hidden>
+               <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>
+               <label class="Form_region">
+                 Region
+                 <select name="region" data-id="form_region" class="Form_select"></select>
+               </label>
+            </div>
+         </form>
 
-      <div class="Form_coverage" data-id="form_coverage" hidden>
-        <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>
-        <label class="Form_region">
-          Region
-          <select name="region" data-id="form_region" class="Form_select"></select>
-        </label>
-      </div>
-    </form>
+         <div class="Hedgehog" data-id="hedgehog">
+            <img
+               srcset="./view/Hedgehog/hedgehog.svg"
+               alt="A hedgehog with a wheelbarrow full of browser logos. He brings them to you!"
+               class="Hedgehog_image"
+               height="316px"
+               width="380px"
+               >
+            <p class="Hedgehog_text">Add the Browserslist config to display compatible browsers.</p>
+         </div>
 
-    <div class="Hedgehog" data-id="hedgehog">
-      <img
-        srcset="./view/Hedgehog/hedgehog.svg"
-        alt="A hedgehog with a wheelbarrow full of browser logos. He brings them to you!"
-        class="Hedgehog_image"
-        height="316px"
-        width="380px"
-      >
-      <p class="Hedgehog_text">Add the Browserslist config to display compatible browsers.</p>
-    </div>
+         <div class="Browsers" data-id="browsers" hidden>
+            <div class="Browsers_scroll">
+               <ul class="Bar" data-id="bar"></ul>
+               <div class="Browsers_results">
+                  <table class="Browsers_table" data-id="browsers_table">
+                  </table>
+               </div>
 
-    <div class="Browsers" data-id="browsers" hidden>
-      <div class="Browsers_scroll">
-        <ul class="Bar" data-id="bar"></ul>
-        <div class="Browsers_results">
-          <table class="Browsers_table" data-id="browsers_table">
-          </table>
-        </div>
+               <div class="Versions">
+                  <p class="Versions_item">
+                     Updated on <strong class="Versions_date" data-id="versions_updated"></strong>
+                  </p>
+                  <p class="Versions_item">
+                     Browserslist <a class="Versions_link" target="_blank" href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md" data-id="versions_browserslist"></a>
+                  </p>
+                  <p class="Versions_item">
+                     Can I Use <a class="Versions_link" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="versions_caniuse"></a>
+                  </p>
+               </div>
+            </div>
+         </div>
+      </main>
 
-        <div class="Versions">
-          <p class="Versions_item">
-            Updated on <strong class="Versions_date" data-id="versions_updated"></strong>
-          </p>
-          <p class="Versions_item">
-            Browserslist <a class="Versions_link" target="_blank" href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md" data-id="versions_browserslist"></a>
-          </p>
-          <p class="Versions_item">
-            Can I Use <a class="Versions_link" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="versions_caniuse"></a>
-          </p>
-        </div>
-      </div>
-    </div>
-  </main>
+      <article class="Docs">
+         <h2>How to get started</h2>
+         <p>
+            Use <a class="QueryLink"><code>defaults</code></a> if you're building a web application for
+            the global audience.
+         </p>
+         <p>
+            Use <a class="QueryLink"><code>node 18</code></a> if you're building a Node.js application,
+            e.g., for server-side rendering.
+         </p>
+         <p>
+            <a href="https://www.npmjs.com/package/autoprefixer" class="Link" target="_blank">Autoprefixer</a>,
+            <a href="https://babeljs.io/" class="Link" target="_blank">Babel</a> and
+            <a href="https://github.com/browserslist/browserslist#browserslist-" class="Link" target="_blank">many other tools</a>
+            will find target browsers automatically if you add the following to <b>package.json</b>:
+         </p>
+         <a class="QueryLink is-pre">
+            <pre>
+              <code>"browserslist": [</code>
+              <code>  "defaults and supports es6-module",</code>
+              <code>  "maintained node versions"</code>
+              <code>]</code>
+            </pre>
+         </a>
+         <h2>Query syntax</h2>
+         <section>
+            <h3>Start with the default configuration</h3>
+            <p>You can pick a sound set of versions with the <a class="QueryLink"><code>defaults</code></a> query which is
+               a shortcut for <code>> 0.5%, last 2 versions, Firefox ESR, not dead</code>.
+               It matches recent versions of popular and supported browsers worldwide and includes
+               Firefox Extended Support Release which is updated roughly annually.
+            </p>
+            <p>The <a class="QueryLink"><code>defaults</code></a> query was thoroughly designed by the
+               Browserslist community.
+               It helps promote best practices and avoid common pitfalls.
+            </p>
+         </section>
 
-  <article class="Docs">
-    <h2>How to get started</h2>
-    <p>
-      Use <a class="QueryLink"><code>defaults</code></a> if you're building a web application for
-      the global audience.
-    </p>
-    <p>
-      Use <a class="QueryLink"><code>node 18</code></a> if you're building a Node.js application,
-      e.g., for server-side rendering.
-    </p>
-    <p>
-      <a href="https://www.npmjs.com/package/autoprefixer" class="Link" target="_blank">Autoprefixer</a>,
-      <a href="https://babeljs.io/" class="Link" target="_blank">Babel</a> and
-      <a href="https://github.com/browserslist/browserslist#browserslist-" class="Link" target="_blank">many other tools</a>
-      will find target browsers automatically if you add the following to <b>package.json</b>:
-    </p>
-    <a class="QueryLink is-pre"><pre>
-      <code>"browserslist": [</code>
-      <code>  "defaults and supports es6-module",</code>
-      <code>  "maintained node versions"</code>
-      <code>]</code>
-    </pre>
-    </a>
-    <h2>Query syntax</h2>
-    <section>
-      <h3>Start with the default configuration</h3>
+         <section>
+            <h3>Select browser versions with certain usage</h3>
+            <p>You can pick versions that have more than or less than a certain size of the
+               audience worldwide, in a region, or in a country. You can also use the visitor
+               data of your own website.
+            </p>
+            <h4>Examples</h4>
+            <ul>
+               <li><a class="QueryLink"><code>> 5%</code></a> all versions with > 5% of the audience
+                  worldwide.
+               </li>
+               <li><a class="QueryLink"><code>>= 5% in US</code></a> same as above but in the US.
+               </li>
+               <li><a class="QueryLink"><code>>= 5% in alt-AS</code></a> same as above but in Asia.
+               </li>
+            </ul>
+            <h4>Beware</h4>
+            <ul>
+               <li> You may exclude the most recent versions of all browsers that have been just
+                  released. Please always add <a class="QueryLink" data-query="last 2 versions"><code>last …
+                  versions</code></a> to include them back.
+               </li>
+               <li> You can exclude your global audience. Please be careful when narrowing the audience to a region or a country.
+               </li>
+               <li> You may include <a class="QueryLink"><code>dead</code></a> versions. Please consider
+                  adding <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
+               </li>
+            </ul>
+            
+            <details>
+               <summary>
+                  <h4>Advanced</h4>
+               </summary>
+               <ul>
+                  <li><a class="QueryLink"><code>> 5% in my stats</code></a> versions with >
+                     5%
+                     of usage
+                     within your own audience.
+                  </li>
+                  <li><a class="QueryLink"><code>> 5% in circle-ci stats</code></a>
+                     versions with > 5% of usage within the audience data from shareable configuration, available as <a
+                        href="https://github.com/circleci/circleci-docs/blob/master/browserslist-stats.json" class="Link"
+                        target="_blank">custom stats</a>.
+                  </li>
+                  <li><a class="QueryLink"><code>cover 99.5%</code></a> the smallest set of popular
+                     versions with collective usage over 99.5% of the audience worldwide.
+                  </li>
+                  <li><a class="QueryLink"><code>cover 99.5% in CN</code></a> same as above
+                     but in China.
+                  </li>
+                  <li><a class="QueryLink"><code>cover 99.5% in alt-EU</code></a> same
+                     as above but in Europe.
+                  </li>
+               </ul>
+            </details>
+         </section>
+         
+         <section>
+            <h3>Select recent browser versions</h3>
+            <p>You can pick a few recent browser versions.</p>
+            <h4>Examples</h4>
+            <ul>
+               <li><a class="QueryLink"><code>last 2 versions</code></a> last 2 versions of each
+                  browser.
+               </li>
+               <li><a class="QueryLink"><code>last 2 Chrome versions</code></a> same as above but just
+                  Chrome.
+               </li>
+            </ul>
+            
+            <h4>Beware</h4>
+            <ul>
+               <li>You might exclude older versions still used by a substantial audience.
+                  Please always add <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include them back.
+               </li>
+               <li>You may pick <a class="QueryLink"><code>dead</code></a> browsers like Internet Explorer.
+                  Always use <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
+                  with <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
+               </li>
+            </ul>
+            
+            <details>
+               <summary>
+                  <h4>Advanced</h4>
+               </summary>
+               <ul>
+                  <li><a class="QueryLink"><code>last 2 major versions</code></a>
+                     all minor and patch releases of the last 2 major versions.
+                  </li>
+                  <li><a class="QueryLink"><code>last 2 Safari major versions</code></a>
+                     same as above but just Safari.
+                  </li>
+                  <li><a class="QueryLink"><code>unreleased versions</code></a>
+                     alpha and beta versions.
+                  </li>
+                  <li><a class="QueryLink"><code>unreleased Chrome versions</code></a>
+                     same as above but just Chrome.
+                  </li>
+                  <li><a class="QueryLink"><code>since 2020-01-15</code></a>
+                     versions released since Jan 15, 2020.
+                  </li>
+                  <li><a class="QueryLink"><code>since 2020-01</code></a>
+                     versions released since January 2020, inclusive.
+                  </li>
+                  <li><a class="QueryLink"><code>since 2020</code></a>
+                     versions released since 2020, inclusive.
+                  </li>
+                  <li><a class="QueryLink"><code>last 3 years</code></a>
+                     same as above if you run this query in 2022.
+                  </li>
+               </ul>
+            </details>
+         </section>
 
-      <p>You can pick a sound set of versions with the <a class="QueryLink"><code>defaults</code></a> query which is
-        a shortcut for <code>> 0.5%, last 2 versions, Firefox ESR, not dead</code>.
-        It matches recent versions of popular and supported browsers worldwide and includes
-        Firefox Extended Support Release which is updated roughly annually.
-      </p>
+         <section>
+            <h3>Select specific browser versions</h3>
+            <p>You can pick browser versions or a version range of your choice.</p>
+            <h4>Examples</h4>
+            <ul>
+               <li><a class="QueryLink"><code>ChromeAndroid 103</code></a> mobile Chrome
+                  version 103.
+               </li>
+               <li><a class="QueryLink"><code>Firefox > 20</code></a> desktop Firefox versions
+                  newer than 20.
+               </li>
+               <li><a class="QueryLink"><code>iOS >= 13.2</code></a> mobile Safari version 13.2
+                  and
+                  newer.
+               </li>
+               <li><a class="QueryLink" data-query="defaults, not firefox esr"><code>not Firefox ESR</code></a> removes specific version.
+               </li>
+            </ul>
+            <h4>Beware</h4>
+            <ul>
+               <li> Make sure that your audience uses specific versions (e.g., in a corporate
+                  setting) or that your application is not built to work with specific
+                  versions (e.g., it's a bleeding-edge demo project). Please consider using
+                  <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
+                  or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
+               </li>
+               <li>Note, that Opera Mini has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
+            </ul>
 
-      <p>The <a class="QueryLink"><code>defaults</code></a> query was thoroughly designed by the
-        Browserslist community.
-        It helps promote best practices and avoid common pitfalls.
-      </p>
-    </section>
+            <details>
+               <summary>
+                  <h4>Advanced</h4>
+               </summary>
+               <ul>
+                  <li><a class="QueryLink"><code>ie 6-8</code></a> an inclusive range of Internet
+                     Explorer
+                     versions.
+                  </li>
+                  <li><a class="QueryLink"><code>Firefox ESR</code></a> the latest Firefox Extended
+                     Support Release.
+                  </li>
+               </ul>
+            </details>
+         </section>
 
-    <section>
-      <h3>Select browser versions with certain usage</h3>
+         <section>
+            <h3>Select specific Node.js versions</h3>
+            <p>You can pick Node.js versions or a version range of your choice. Useful if you
+               know for sure the runtime configuration of your server-side code.
+            </p>
+            <h4>Examples</h4>
+            <ul>
+               <li><a class="QueryLink"><code>node 10</code></a> latest
+                  <a class="QueryLink" data-query="node 10.0.0"><code>10.x.x</code></a> Node.js version.
+               </li>
+               <li><a class="QueryLink"><code>node 10.4</code></a> latest
+                  <a class="QueryLink" data-query="node 10.4.0"><code>10.4.x</code></a> Node.js version.
+               </li>
+               <li><a class="QueryLink"><code>node > 16</code></a> all Node.js versions newer than
+                  <code>16.0.0</code>.
+               </li>
+               <li><a class="QueryLink"><code>last 2 node versions</code></a> two latest Node.js releases.
+               </li>
+               <li><a class="QueryLink"><code>last 2 node major versions</code></a> two last major-version Node.js releases.
+               </li>
+            </ul>
 
-      <p>You can pick versions that have more than or less than a certain size of the
-        audience worldwide, in a region, or in a country. You can also use the visitor
-        data of your own website.</p>
+            <details>
+               <summary>
+                  <h4>Advanced</h4>
+               </summary>
+               <ul>
+                  <li><a class="QueryLink"><code>maintained node versions</code></a>
+                     all Node.js versions currently maintained by Node.js Foundation.
+                  </li>
+                  <li><a class="QueryLink"><code>current node</code></a> the Node.js version used
+                     by Browserslist right now.
+                  </li>
+               </ul>
+            </details>
+         </section>
 
-      <h4>Examples</h4>
-      <ul>
-        <li><a class="QueryLink"><code>> 5%</code></a> all versions with > 5% of the audience
-          worldwide.
-        </li>
-        <li><a class="QueryLink"><code>>= 5% in US</code></a> same as above but in the US.
-        </li>
-        <li><a class="QueryLink"><code>>= 5% in alt-AS</code></a> same as above but in Asia.
-        </li>
-      </ul>
+         <section>
+            <h3>Select browser versions that support a certain feature</h3>
+            <p>You can pick browser versions that fully support features from the Can I Use database. See the
+               <a href="https://github.com/browserslist/caniuse-lite/tree/main/data/features" class="Link" target="_blank">
+               caniuse-lite repository</a> for the full list of features.
+            </p>
+            <h4>Examples</h4>
+            <ul>
+               <li><a class="QueryLink"><code>supports es6-module</code></a> versions that support
+                  JavaScript modules via script tag.
+               </li>
+               <li><a class="QueryLink"><code>supports css-grid</code></a> versions that support CSS Grid Layout.</li>
+            </ul>
+            <h4>Beware</h4>
+            <ul>
+               <li> This query rarely works well on its own. Please consider combining it with other queries.
+               </li>
+            </ul>
+         </section>
 
-      <h4>Beware</h4>
-      <ul>
-        <li> You may exclude the most recent versions of all browsers that have been just
-          released. Please always add <a class="QueryLink" data-query="last 2 versions"><code>last …
-            versions</code></a> to include them back.
-        </li>
-        <li> You can exclude your global audience. Please be careful when narrowing the audience to a region or a country.
-        </li>
-        <li> You may include <a class="QueryLink"><code>dead</code></a> versions. Please consider
-          adding <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
-        </li>
-      </ul>
+         <section>
+            <h3>Combine multiple queries into one</h3>
+            <p>You can combine versions matched by multiple queries with <code>or</code> or <code>,</code>; you can
+               intersect them with <code>and</code>. You can also negate any query with <code>not</code> if it's
+               not the first one in your list.
+            </p>
+            <h4>Examples</h4>
+            <ul>
+               <li>
+                  <a class="QueryLink"><code>> 0.5%, last 2 versions</code></a>
+                  combines <a class="QueryLink"><code>> 0.5%</code></a>
+                  with <a class="QueryLink"><code>last 2 versions</code></a>.
+               </li>
+               <li><a class="QueryLink"><code>> 0.5% or last 2 versions</code></a>
+                  same as above.
+               </li>
+               <li><a class="QueryLink"><code>> 0.5% and last 2 versions</code></a>
+                  intersects <a class="QueryLink"><code>> 0.5%</code></a>
+                  with <a class="QueryLink"><code>last 2 versions</code></a>.
+               </li>
+               <li><a class="QueryLink"><code>> 0.5% and not last 2 versions</code></a> removes
+                  <a class="QueryLink"><code>last 2 versions</code></a> from
+                  <a class="QueryLink"><code>> 0.5%</code></a>.
+               </li>
+            </ul>
 
-      <details>
-        <summary><h4>Advanced</h4></summary>
-        <ul>
-          <li><a class="QueryLink"><code>> 5% in my stats</code></a> versions with >
-            5%
-            of usage
-            within your own audience.
-          </li>
-          <li><a class="QueryLink"><code>> 5% in circle-ci stats</code></a>
-            versions with > 5% of usage within the audience data from shareable configuration, available as <a
-              href="https://github.com/circleci/circleci-docs/blob/master/browserslist-stats.json" class="Link"
-              target="_blank">custom stats</a>.
-          </li>
-          <li><a class="QueryLink"><code>cover 99.5%</code></a> the smallest set of popular
-            versions with collective usage over 99.5% of the audience worldwide.
-          </li>
-          <li><a class="QueryLink"><code>cover 99.5% in CN</code></a> same as above
-            but in China.
-          </li>
-          <li><a class="QueryLink"><code>cover 99.5% in alt-EU</code></a> same
-            as above but in Europe.
-          </li>
-        </ul>
-      </details>
-    </section>
+            <h4>Beware</h4>
+            <ul>
+               <li> A query with <a class="QueryLink" data-query="defaults, not last 2 versions"><code>not</code></a>
+                  can't be the left-hand one in the list.
+               </li>
+               <li> A query with <code>not</code> is always joined to the left-hand one with
+                  <a class="QueryLink" data-query="defaults and not last 2 versions"><code>and</code></a>,
+                  even if <a class="QueryLink" data-query="defaults or not last 2 versions"><code>or</code></a> or
+                  <a class="QueryLink" data-query="defaults, not last 2 versions"><code>,</code></a> are used.
+               </li>
+            </ul>
 
-    <section>
-      <h3>Select recent browser versions</h3>
+            <details>
+               <summary>
+                  <h4>Advanced</h4>
+               </summary>
+               <ul>
+                  <li>
+                     The following queries yield the same result:
+                     <a class="QueryLink"> <code>> 0.5% and not last 2 versions</code></a>,
+                     <a class="QueryLink"><code>> 0.5% or not last 2 versions</code></a>,
+                     <a class="QueryLink"><code>> 0.5%, not last 2 versions</code></a>.
+                  </li>
+               </ul>
+            </details>
+         </section>
 
-      <p>You can pick a few recent browser versions.</p>
+         <section>
+            <h3>Exclude unmaintained browser versions</h3>
+            <p>You can combine your queries with
+               <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>
+               to exclude <a class="QueryLink"><code>dead</code></a> browsers, i.e.,
+               browsers without official support or updates for more than 24 months.
+               Right now these include IE 11, IE Mobile 11, BlackBerry 10, BlackBerry 7,
+               Samsung 4, Opera Mobile 12.1, and all versions of Baidu.
+            </p>
+            <h4>Examples</h4>
+            <ul>
+               <li><a class="QueryLink"><code>> 0.2% and not dead</code></a>
+                  excludes <a class="QueryLink"><code>dead</code></a> versions
+                  from versions matched by <a class="QueryLink"><code>> 0.2%</code></a>.
+               </li>
+            </ul>
+         </section>
 
-      <h4>Examples</h4>
-      <ul>
-        <li><a class="QueryLink"><code>last 2 versions</code></a> last 2 versions of each
-          browser.
-        </li>
-        <li><a class="QueryLink"><code>last 2 Chrome versions</code></a> same as above but just
-          Chrome.
-        </li>
-      </ul>
+         <h2>Why Browserslist</h2>
+         <p>Browserslist helps you keep the right balance between browser compatibility and bundle size.
+            With Browserslist, you will cover wider audience and have smaller bundle size. 
+         </p>
+      </article>
 
-      <h4>Beware</h4>
-      <ul>
-        <li>You might exclude older versions still used by a substantial audience.
-          Please always add <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include them back.
-        </li>
-        <li>You may pick <a class="QueryLink"><code>dead</code></a> browsers like Internet Explorer.
-          Always use <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
-          with <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
-        </li>
-      </ul>
-
-      <details>
-        <summary><h4>Advanced</h4></summary>
-        <ul>
-          <li><a class="QueryLink"><code>last 2 major versions</code></a> all
-            minor
-            and patch releases of the last 2 major versions.
-          </li>
-          <li><a class="QueryLink"><code>last 2 Safari major
-            versions</code></a>
-            same as above but just Safari.
-          </li>
-          <li><a class="QueryLink"><code>unreleased versions</code></a>
-            alpha and beta versions.
-          </li>
-          <li><a class="QueryLink"><code>unreleased Chrome versions</code></a>
-            same as above but just Chrome.
-          </li>
-          <li><a class="QueryLink"><code>since 2020-01-15</code></a>
-            versions released since Jan 15, 2020.
-          </li>
-          <li><a class="QueryLink"><code>since 2020-01</code></a>
-            versions released since January 2020, inclusive.
-          </li>
-          <li><a class="QueryLink"><code>since 2020</code></a>
-            versions released since 2020, inclusive.
-          </li>
-          <li><a class="QueryLink"><code>last 3 years</code></a>
-            same as above if you run this query in 2022.
-          </li>
-        </ul>
-      </details>
-    </section>
-
-    <section>
-      <h3>Select specific browser versions</h3>
-
-      <p>You can pick browser versions or a version range of your choice.</p>
-
-      <h4>Examples</h4>
-      <ul>
-        <li><a class="QueryLink"><code>ChromeAndroid 103</code></a> mobile Chrome
-          version 103.
-        </li>
-        <li><a class="QueryLink"><code>Firefox > 20</code></a> desktop Firefox versions
-          newer than 20.
-        </li>
-        <li><a class="QueryLink"><code>iOS >= 13.2</code></a> mobile Safari version 13.2
-          and
-          newer.
-        </li>
-        <li><a class="QueryLink" data-query="defaults, not firefox esr"><code>not Firefox ESR</code></a> removes specific version.
-        </li>
-      </ul>
-
-      <h4>Beware</h4>
-      <ul>
-        <li> Make sure that your audience uses specific versions (e.g., in a corporate
-          setting) or that your application is not built to work with specific
-          versions (e.g., it's a bleeding-edge demo project). Please consider using
-          <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
-          or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
-        </li>
-        <li>Note, that Opera Mini has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
-      </ul>
-
-      <details>
-        <summary><h4>Advanced</h4></summary>
-        <ul>
-          <li><a class="QueryLink"><code>ie 6-8</code></a> an inclusive range of Internet
-            Explorer
-            versions.
-          </li>
-          <li><a class="QueryLink"><code>Firefox ESR</code></a> the latest Firefox Extended
-            Support Release.
-          </li>
-        </ul>
-      </details>
-    </section>
-
-    <section>
-      <h3>Select specific Node.js versions</h3>
-
-      <p>You can pick Node.js versions or a version range of your choice. Useful if you
-        know for sure the runtime configuration of your server-side code.</p>
-
-      <h4>Examples</h4>
-      <ul>
-        <li><a class="QueryLink"><code>node 10</code></a> latest
-          <a class="QueryLink" data-query="node 10.0.0"><code>10.x.x</code></a> Node.js version.
-        </li>
-        <li><a class="QueryLink"><code>node 10.4</code></a> latest
-          <a class="QueryLink" data-query="node 10.4.0"><code>10.4.x</code></a> Node.js version.
-        </li>
-        <li><a class="QueryLink"><code>node > 16</code></a> all Node.js versions newer than
-          <code>16.0.0</code>.
-        </li>
-        <li><a class="QueryLink"><code>last 2 node versions</code></a> two latest Node.js releases.
-        </li>
-        <li><a class="QueryLink"><code>last 2 node major versions</code></a> two last major-version Node.js releases.
-        </li>
-      </ul>
-
-      <details>
-        <summary><h4>Advanced</h4></summary>
-        <ul>
-          <li><a class="QueryLink"><code>maintained node versions</code></a>
-            all Node.js versions currently maintained by Node.js Foundation.
-          </li>
-          <li><a class="QueryLink"><code>current node</code></a> the Node.js version used
-            by Browserslist right now.
-          </li>
-        </ul>
-      </details>
-    </section>
-
-    <section>
-      <h3>Select browser versions that support a certain feature</h3>
-
-      <p>You can pick browser versions that fully support features from the Can I Use database. See the
-        <a href="https://github.com/browserslist/caniuse-lite/tree/main/data/features" class="Link" target="_blank">
-          caniuse-lite repository</a> for the full list of features.</p>
-
-      <h4>Examples</h4>
-      <ul>
-        <li><a class="QueryLink"><code>supports es6-module</code></a> versions that support
-          JavaScript modules via script tag.
-        </li>
-        <li><a class="QueryLink"><code>supports css-grid</code></a> versions that support CSS Grid Layout.</li>
-      </ul>
-
-      <h4>Beware</h4>
-      <ul>
-        <li> This query rarely works well on its own. Please consider combining it with other queries.
-        </li>
-      </ul>
-    </section>
-
-    <section>
-      <h3>Combine multiple queries into one</h3>
-
-      <p>You can combine versions matched by multiple queries with <code>or</code> or <code>,</code>; you can
-        intersect them with <code>and</code>. You can also negate any query with <code>not</code> if it's
-        not the first one in your list.</p>
-
-      <h4>Examples</h4>
-      <ul>
-        <li>
-          <a class="QueryLink"><code>> 0.5%, last 2 versions</code></a>
-          combines <a class="QueryLink"><code>> 0.5%</code></a>
-          with <a class="QueryLink"><code>last 2 versions</code></a>.
-        </li>
-        <li><a class="QueryLink"><code>> 0.5% or last 2 versions</code></a>
-          same as above.
-        </li>
-        <li><a class="QueryLink"><code>> 0.5% and last 2 versions</code></a>
-          intersects <a class="QueryLink"><code>> 0.5%</code></a>
-          with <a class="QueryLink"><code>last 2 versions</code></a>.
-        </li>
-        <li><a class="QueryLink"><code>> 0.5% and not last 2 versions</code></a> removes
-          <a class="QueryLink"><code>last 2 versions</code></a> from
-          <a class="QueryLink"><code>> 0.5%</code></a>.
-        </li>
-      </ul>
-
-      <h4>Beware</h4>
-      <ul>
-        <li> A query with <a class="QueryLink" data-query="defaults, not last 2 versions"><code>not</code></a>
-          can't be the left-hand one in the list.</li>
-        <li> A query with <code>not</code> is always joined to the left-hand one with
-          <a class="QueryLink" data-query="defaults and not last 2 versions"><code>and</code></a>,
-          even if <a class="QueryLink" data-query="defaults or not last 2 versions"><code>or</code></a> or
-          <a class="QueryLink" data-query="defaults, not last 2 versions"><code>,</code></a> are used.</li>
-      </ul>
-
-      <details>
-        <summary><h4>Advanced</h4></summary>
-        <ul>
-          <li>
-            The following queries yield the same result:
-            <a class="QueryLink"> <code>> 0.5% and not last 2 versions</code></a>,
-            <a class="QueryLink"><code>> 0.5% or not last 2 versions</code></a>,
-            <a class="QueryLink"><code>> 0.5%, not last 2 versions</code></a>.
-          </li>
-        </ul>
-      </details>
-    </section>
-
-    <section>
-      <h3>Exclude unmaintained browser versions</h3>
-
-      <p>You can combine your queries with
-        <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>
-        to exclude <a class="QueryLink"><code>dead</code></a> browsers, i.e.,
-        browsers without official support or updates for more than 24 months.
-        Right now these include IE 11, IE Mobile 11, BlackBerry 10, BlackBerry 7,
-        Samsung 4, Opera Mobile 12.1, and all versions of Baidu.</p>
-
-      <h4>Examples</h4>
-      <ul>
-        <li><a class="QueryLink"><code>> 0.2% and not dead</code></a>
-          excludes <a class="QueryLink"><code>dead</code></a> versions
-          from versions matched by <a class="QueryLink"><code>> 0.2%</code></a>.
-        </li>
-      </ul>
-    </section>
-
-    <h2>Why Browserslist</h2>
-    <p>Browserslist helps you keep the right balance between browser compatibility and bundle size.
-      With Browserslist, you will cover wider audience and have smaller bundle size. </p>
-  </article>
-
-  <footer class="Footer">
-    <a class="Badge is-github" href="https://github.com/browserslist/browsersl.ist" target="_blank">
-      <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
-    </a>
-  </footer>
-</body>
+      <footer class="Footer">
+         <a class="Badge is-github" href="https://github.com/browserslist/browsersl.ist" target="_blank">
+         <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
+         </a>
+      </footer>
+   </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -431,7 +431,7 @@
 
   <footer class="Footer">
     <a class="Badge is-github" href="https://github.com/browserslist/browsersl.ist" target="_blank">
-    <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
+      <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
     </a>
   </footer>
 </body>

--- a/client/index.html
+++ b/client/index.html
@@ -40,7 +40,7 @@
       <a href="https://cube.dev/?ref=eco-browserslist" class="Link is-image" target="_blank"><img class="Intro_cube" src="./view/Intro/cube.svg" alt=""> <span class="Link_text">Cube</span></a>
     </p>
   </header>
-  
+
   <main class="Interactive" data-id="interactive">
     <h2 class="Interactive_title">Check compatible browsers</h2>
     <form data-id="form" class="Form">
@@ -71,8 +71,7 @@
         alt="A hedgehog with a wheelbarrow full of browser logos. He brings them to you!"
         class="Hedgehog_image"
         height="316px"
-        width="380px"
-        >
+        width="380px">
       <p class="Hedgehog_text">Add the Browserslist config to display compatible browsers.</p>
     </div>
 
@@ -165,7 +164,7 @@
           adding <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
         </li>
       </ul>
-      
+
       <details>
         <summary>
           <h4>Advanced</h4>
@@ -193,7 +192,7 @@
         </ul>
       </details>
     </section>
-    
+
     <section>
       <h3>Select recent browser versions</h3>
       <p>You can pick a few recent browser versions.</p>
@@ -206,7 +205,7 @@
           Chrome.
         </li>
       </ul>
-      
+
       <h4>Beware</h4>
       <ul>
         <li>You might exclude older versions still used by a substantial audience.
@@ -217,7 +216,7 @@
           with <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
         </li>
       </ul>
-      
+
       <details>
         <summary>
           <h4>Advanced</h4>

--- a/client/index.html
+++ b/client/index.html
@@ -1,439 +1,439 @@
 <!DOCTYPE html>
 <html lang="en">
-   <head>
-      <meta charset="UTF-8">
-      <meta name="color-scheme" content="dark light">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
-      <title>Browserslist</title>
-      <meta name="description" content="Display target browsers from a Browserslist config">
-      <meta property="og:image" content="https://browsersl.ist/og.png">
-      <link rel="stylesheet" href="./index.css">
-      <script type="module" src="./index.js" defer></script>
-      <link rel="preload" href="./view/MartianMono/MartianMono-0.9.1.woff2" as="font" type="font/woff2" crossorigin />
-      <link rel="icon" href="/favicon.ico" sizes="any">
-      <link rel="icon" href="./view/Base/icon.svg" type="image/svg+xml">
-      <link rel="apple-touch-icon" href="./view/Base/apple-touch-icon.png">
-      <link rel="manifest" href="/browserslist.webmanifest">
-   </head>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="color-scheme" content="dark light">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Browserslist</title>
+    <meta name="description" content="Display target browsers from a Browserslist config">
+    <meta property="og:image" content="https://browsersl.ist/og.png">
+    <link rel="stylesheet" href="./index.css">
+    <script type="module" src="./index.js" defer></script>
+    <link rel="preload" href="./view/MartianMono/MartianMono-0.9.1.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="icon" href="./view/Base/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="./view/Base/apple-touch-icon.png">
+    <link rel="manifest" href="/browserslist.webmanifest">
+  </head>
 
-   <body>
-      <header class="Intro">
-         <button class="Skip" data-id="skip">Skip to form</button>
-         <div class="Intro_header">
-            <h1 class="Intro_title">
-               <img class="Intro_logo" src="./view/Intro/browserlist.svg" alt="">
-               Browserslist
-            </h1>
-            <a class="Badge is-github" href="https://github.com/browserslist/browserslist" target="_blank">
-              <img src="./view/Badge/github.svg" alt="Count of GitHub stars" class="Badge_logo"> 11K
-            </a>
-            <a class="Badge" href="https://twitter.com/Browserslist"  target="_blank">
-              <img src="./view/Badge/twitter.svg" alt="Count of Twitter followers" class="Badge_logo"> 1728
-            </a>
-         </div>
-         <p class="Intro_about">Shared browser compatibility config for popular JavaScript tools
-            like Autoprefixer, Babel, ESLint, PostCSS, and Webpack
-         </p>
-         <p class="Intro_supported">
-            Supported by
-            <a href="https://evilmartians.com/" class="Link is-image" target="_blank"><img class="Intro_martians" src="./view/Intro/evil_maritians.svg" alt=""> <span class="Link_text">Evil Martians</span></a> and
-            <a href="https://cube.dev/?ref=eco-browserslist" class="Link is-image" target="_blank"><img class="Intro_cube" src="./view/Intro/cube.svg" alt=""> <span class="Link_text">Cube</span></a>
-         </p>
-      </header>
+  <body>
+    <header class="Intro">
+      <button class="Skip" data-id="skip">Skip to form</button>
+      <div class="Intro_header">
+        <h1 class="Intro_title">
+          <img class="Intro_logo" src="./view/Intro/browserlist.svg" alt="">
+          Browserslist
+        </h1>
+        <a class="Badge is-github" href="https://github.com/browserslist/browserslist" target="_blank">
+          <img src="./view/Badge/github.svg" alt="Count of GitHub stars" class="Badge_logo"> 11K
+        </a>
+        <a class="Badge" href="https://twitter.com/Browserslist"  target="_blank">
+          <img src="./view/Badge/twitter.svg" alt="Count of Twitter followers" class="Badge_logo"> 1728
+        </a>
+      </div>
+      <p class="Intro_about">Shared browser compatibility config for popular JavaScript tools
+        like Autoprefixer, Babel, ESLint, PostCSS, and Webpack
+      </p>
+      <p class="Intro_supported">
+        Supported by
+        <a href="https://evilmartians.com/" class="Link is-image" target="_blank"><img class="Intro_martians" src="./view/Intro/evil_maritians.svg" alt=""> <span class="Link_text">Evil Martians</span></a> and
+        <a href="https://cube.dev/?ref=eco-browserslist" class="Link is-image" target="_blank"><img class="Intro_cube" src="./view/Intro/cube.svg" alt=""> <span class="Link_text">Cube</span></a>
+      </p>
+    </header>
+    
+    <main class="Interactive" data-id="interactive">
+      <h2 class="Interactive_title">Check compatible browsers</h2>
+      <form data-id="form" class="Form">
+        <div class="Form_query">
+          <textarea id="form_query" name="query" cols="30" rows="5" required class="Form_textarea" data-id="form_textarea" placeholder="Write the Browserslist config here…"></textarea>
+          <label for="form_query" class="Form_placeholder">Write the Browserslist config here…<br>
+            For example
+            <a class="QueryLink"><code>defaults</code></a>,
+            <a class="QueryLink"><code>> 0.2% and not dead</code></a>
+          </label>
+          <p class="Form_loader">Loading…</p>
+        </div>
+
+        <div class="Form_messages" data-id="form_messages"></div>
+
+        <div class="Form_coverage" data-id="form_coverage" hidden>
+          <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>
+          <label class="Form_region">
+            Region
+            <select name="region" data-id="form_region" class="Form_select"></select>
+          </label>
+        </div>
+      </form>
+
+      <div class="Hedgehog" data-id="hedgehog">
+        <img
+          srcset="./view/Hedgehog/hedgehog.svg"
+          alt="A hedgehog with a wheelbarrow full of browser logos. He brings them to you!"
+          class="Hedgehog_image"
+          height="316px"
+          width="380px"
+          >
+        <p class="Hedgehog_text">Add the Browserslist config to display compatible browsers.</p>
+      </div>
+
+      <div class="Browsers" data-id="browsers" hidden>
+        <div class="Browsers_scroll">
+          <ul class="Bar" data-id="bar"></ul>
+          <div class="Browsers_results">
+            <table class="Browsers_table" data-id="browsers_table">
+            </table>
+          </div>
+
+          <div class="Versions">
+            <p class="Versions_item">
+              Updated on <strong class="Versions_date" data-id="versions_updated"></strong>
+            </p>
+            <p class="Versions_item">
+              Browserslist <a class="Versions_link" target="_blank" href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md" data-id="versions_browserslist"></a>
+            </p>
+            <p class="Versions_item">
+              Can I Use <a class="Versions_link" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="versions_caniuse"></a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <article class="Docs">
+      <h2>How to get started</h2>
+      <p>
+        Use <a class="QueryLink"><code>defaults</code></a> if you're building a web application for
+        the global audience.
+      </p>
+      <p>
+        Use <a class="QueryLink"><code>node 18</code></a> if you're building a Node.js application,
+        e.g., for server-side rendering.
+      </p>
+      <p>
+        <a href="https://www.npmjs.com/package/autoprefixer" class="Link" target="_blank">Autoprefixer</a>,
+        <a href="https://babeljs.io/" class="Link" target="_blank">Babel</a> and
+        <a href="https://github.com/browserslist/browserslist#browserslist-" class="Link" target="_blank">many other tools</a>
+        will find target browsers automatically if you add the following to <b>package.json</b>:
+      </p>
+      <a class="QueryLink is-pre">
+        <pre>
+          <code>"browserslist": [</code>
+          <code>  "defaults and supports es6-module",</code>
+          <code>  "maintained node versions"</code>
+          <code>]</code>
+        </pre>
+      </a>
+      <h2>Query syntax</h2>
+      <section>
+        <h3>Start with the default configuration</h3>
+        <p>You can pick a sound set of versions with the <a class="QueryLink"><code>defaults</code></a> query which is
+          a shortcut for <code>> 0.5%, last 2 versions, Firefox ESR, not dead</code>.
+          It matches recent versions of popular and supported browsers worldwide and includes
+          Firefox Extended Support Release which is updated roughly annually.
+        </p>
+        <p>The <a class="QueryLink"><code>defaults</code></a> query was thoroughly designed by the
+          Browserslist community.
+          It helps promote best practices and avoid common pitfalls.
+        </p>
+      </section>
+
+      <section>
+        <h3>Select browser versions with certain usage</h3>
+        <p>You can pick versions that have more than or less than a certain size of the
+          audience worldwide, in a region, or in a country. You can also use the visitor
+          data of your own website.
+        </p>
+        <h4>Examples</h4>
+        <ul>
+          <li><a class="QueryLink"><code>> 5%</code></a> all versions with > 5% of the audience
+            worldwide.
+          </li>
+          <li><a class="QueryLink"><code>>= 5% in US</code></a> same as above but in the US.
+          </li>
+          <li><a class="QueryLink"><code>>= 5% in alt-AS</code></a> same as above but in Asia.
+          </li>
+        </ul>
+        <h4>Beware</h4>
+        <ul>
+          <li> You may exclude the most recent versions of all browsers that have been just
+            released. Please always add <a class="QueryLink" data-query="last 2 versions"><code>last …
+            versions</code></a> to include them back.
+          </li>
+          <li> You can exclude your global audience. Please be careful when narrowing the audience to a region or a country.
+          </li>
+          <li> You may include <a class="QueryLink"><code>dead</code></a> versions. Please consider
+            adding <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
+          </li>
+        </ul>
+        
+        <details>
+          <summary>
+            <h4>Advanced</h4>
+          </summary>
+          <ul>
+            <li><a class="QueryLink"><code>> 5% in my stats</code></a> versions with >
+              5%
+              of usage
+              within your own audience.
+            </li>
+            <li><a class="QueryLink"><code>> 5% in circle-ci stats</code></a>
+              versions with > 5% of usage within the audience data from shareable configuration, available as <a
+                href="https://github.com/circleci/circleci-docs/blob/master/browserslist-stats.json" class="Link"
+                target="_blank">custom stats</a>.
+            </li>
+            <li><a class="QueryLink"><code>cover 99.5%</code></a> the smallest set of popular
+              versions with collective usage over 99.5% of the audience worldwide.
+            </li>
+            <li><a class="QueryLink"><code>cover 99.5% in CN</code></a> same as above
+              but in China.
+            </li>
+            <li><a class="QueryLink"><code>cover 99.5% in alt-EU</code></a> same
+              as above but in Europe.
+            </li>
+          </ul>
+        </details>
+      </section>
       
-      <main class="Interactive" data-id="interactive">
-         <h2 class="Interactive_title">Check compatible browsers</h2>
-         <form data-id="form" class="Form">
-            <div class="Form_query">
-               <textarea id="form_query" name="query" cols="30" rows="5" required class="Form_textarea" data-id="form_textarea" placeholder="Write the Browserslist config here…"></textarea>
-               <label for="form_query" class="Form_placeholder">Write the Browserslist config here…<br>
-                 For example
-                 <a class="QueryLink"><code>defaults</code></a>,
-                 <a class="QueryLink"><code>> 0.2% and not dead</code></a>
-               </label>
-               <p class="Form_loader">Loading…</p>
-            </div>
+      <section>
+        <h3>Select recent browser versions</h3>
+        <p>You can pick a few recent browser versions.</p>
+        <h4>Examples</h4>
+        <ul>
+          <li><a class="QueryLink"><code>last 2 versions</code></a> last 2 versions of each
+            browser.
+          </li>
+          <li><a class="QueryLink"><code>last 2 Chrome versions</code></a> same as above but just
+            Chrome.
+          </li>
+        </ul>
+        
+        <h4>Beware</h4>
+        <ul>
+          <li>You might exclude older versions still used by a substantial audience.
+            Please always add <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include them back.
+          </li>
+          <li>You may pick <a class="QueryLink"><code>dead</code></a> browsers like Internet Explorer.
+            Always use <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
+            with <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
+          </li>
+        </ul>
+        
+        <details>
+          <summary>
+            <h4>Advanced</h4>
+          </summary>
+          <ul>
+            <li><a class="QueryLink"><code>last 2 major versions</code></a>
+              all minor and patch releases of the last 2 major versions.
+            </li>
+            <li><a class="QueryLink"><code>last 2 Safari major versions</code></a>
+              same as above but just Safari.
+            </li>
+            <li><a class="QueryLink"><code>unreleased versions</code></a>
+              alpha and beta versions.
+            </li>
+            <li><a class="QueryLink"><code>unreleased Chrome versions</code></a>
+              same as above but just Chrome.
+            </li>
+            <li><a class="QueryLink"><code>since 2020-01-15</code></a>
+              versions released since Jan 15, 2020.
+            </li>
+            <li><a class="QueryLink"><code>since 2020-01</code></a>
+              versions released since January 2020, inclusive.
+            </li>
+            <li><a class="QueryLink"><code>since 2020</code></a>
+              versions released since 2020, inclusive.
+            </li>
+            <li><a class="QueryLink"><code>last 3 years</code></a>
+              same as above if you run this query in 2022.
+            </li>
+          </ul>
+        </details>
+      </section>
 
-            <div class="Form_messages" data-id="form_messages"></div>
+      <section>
+        <h3>Select specific browser versions</h3>
+        <p>You can pick browser versions or a version range of your choice.</p>
+        <h4>Examples</h4>
+        <ul>
+          <li><a class="QueryLink"><code>ChromeAndroid 103</code></a> mobile Chrome
+            version 103.
+          </li>
+          <li><a class="QueryLink"><code>Firefox > 20</code></a> desktop Firefox versions
+            newer than 20.
+          </li>
+          <li><a class="QueryLink"><code>iOS >= 13.2</code></a> mobile Safari version 13.2
+            and
+            newer.
+          </li>
+          <li><a class="QueryLink" data-query="defaults, not firefox esr"><code>not Firefox ESR</code></a> removes specific version.
+          </li>
+        </ul>
+        <h4>Beware</h4>
+        <ul>
+          <li> Make sure that your audience uses specific versions (e.g., in a corporate
+            setting) or that your application is not built to work with specific
+            versions (e.g., it's a bleeding-edge demo project). Please consider using
+            <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
+            or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
+          </li>
+          <li>Note, that Opera Mini has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
+        </ul>
 
-            <div class="Form_coverage" data-id="form_coverage" hidden>
-               <h2 class="Interactive_title">Audience coverage: <span data-id="form_total"></span></h2>
-               <label class="Form_region">
-                 Region
-                 <select name="region" data-id="form_region" class="Form_select"></select>
-               </label>
-            </div>
-         </form>
+        <details>
+          <summary>
+            <h4>Advanced</h4>
+          </summary>
+          <ul>
+            <li><a class="QueryLink"><code>ie 6-8</code></a> an inclusive range of Internet
+              Explorer
+              versions.
+            </li>
+            <li><a class="QueryLink"><code>Firefox ESR</code></a> the latest Firefox Extended
+              Support Release.
+            </li>
+          </ul>
+        </details>
+      </section>
 
-         <div class="Hedgehog" data-id="hedgehog">
-            <img
-               srcset="./view/Hedgehog/hedgehog.svg"
-               alt="A hedgehog with a wheelbarrow full of browser logos. He brings them to you!"
-               class="Hedgehog_image"
-               height="316px"
-               width="380px"
-               >
-            <p class="Hedgehog_text">Add the Browserslist config to display compatible browsers.</p>
-         </div>
+      <section>
+        <h3>Select specific Node.js versions</h3>
+        <p>You can pick Node.js versions or a version range of your choice. Useful if you
+          know for sure the runtime configuration of your server-side code.
+        </p>
+        <h4>Examples</h4>
+        <ul>
+          <li><a class="QueryLink"><code>node 10</code></a> latest
+            <a class="QueryLink" data-query="node 10.0.0"><code>10.x.x</code></a> Node.js version.
+          </li>
+          <li><a class="QueryLink"><code>node 10.4</code></a> latest
+            <a class="QueryLink" data-query="node 10.4.0"><code>10.4.x</code></a> Node.js version.
+          </li>
+          <li><a class="QueryLink"><code>node > 16</code></a> all Node.js versions newer than
+            <code>16.0.0</code>.
+          </li>
+          <li><a class="QueryLink"><code>last 2 node versions</code></a> two latest Node.js releases.
+          </li>
+          <li><a class="QueryLink"><code>last 2 node major versions</code></a> two last major-version Node.js releases.
+          </li>
+        </ul>
 
-         <div class="Browsers" data-id="browsers" hidden>
-            <div class="Browsers_scroll">
-               <ul class="Bar" data-id="bar"></ul>
-               <div class="Browsers_results">
-                  <table class="Browsers_table" data-id="browsers_table">
-                  </table>
-               </div>
+        <details>
+          <summary>
+            <h4>Advanced</h4>
+          </summary>
+          <ul>
+            <li><a class="QueryLink"><code>maintained node versions</code></a>
+              all Node.js versions currently maintained by Node.js Foundation.
+            </li>
+            <li><a class="QueryLink"><code>current node</code></a> the Node.js version used
+              by Browserslist right now.
+            </li>
+          </ul>
+        </details>
+      </section>
 
-               <div class="Versions">
-                  <p class="Versions_item">
-                     Updated on <strong class="Versions_date" data-id="versions_updated"></strong>
-                  </p>
-                  <p class="Versions_item">
-                     Browserslist <a class="Versions_link" target="_blank" href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md" data-id="versions_browserslist"></a>
-                  </p>
-                  <p class="Versions_item">
-                     Can I Use <a class="Versions_link" target="_blank" href="https://www.npmjs.com/package/caniuse-lite" data-id="versions_caniuse"></a>
-                  </p>
-               </div>
-            </div>
-         </div>
-      </main>
+      <section>
+        <h3>Select browser versions that support a certain feature</h3>
+        <p>You can pick browser versions that fully support features from the Can I Use database. See the
+          <a href="https://github.com/browserslist/caniuse-lite/tree/main/data/features" class="Link" target="_blank">
+          caniuse-lite repository</a> for the full list of features.
+        </p>
+        <h4>Examples</h4>
+        <ul>
+          <li><a class="QueryLink"><code>supports es6-module</code></a> versions that support
+            JavaScript modules via script tag.
+          </li>
+          <li><a class="QueryLink"><code>supports css-grid</code></a> versions that support CSS Grid Layout.</li>
+        </ul>
+        <h4>Beware</h4>
+        <ul>
+          <li> This query rarely works well on its own. Please consider combining it with other queries.
+          </li>
+        </ul>
+      </section>
 
-      <article class="Docs">
-         <h2>How to get started</h2>
-         <p>
-            Use <a class="QueryLink"><code>defaults</code></a> if you're building a web application for
-            the global audience.
-         </p>
-         <p>
-            Use <a class="QueryLink"><code>node 18</code></a> if you're building a Node.js application,
-            e.g., for server-side rendering.
-         </p>
-         <p>
-            <a href="https://www.npmjs.com/package/autoprefixer" class="Link" target="_blank">Autoprefixer</a>,
-            <a href="https://babeljs.io/" class="Link" target="_blank">Babel</a> and
-            <a href="https://github.com/browserslist/browserslist#browserslist-" class="Link" target="_blank">many other tools</a>
-            will find target browsers automatically if you add the following to <b>package.json</b>:
-         </p>
-         <a class="QueryLink is-pre">
-            <pre>
-              <code>"browserslist": [</code>
-              <code>  "defaults and supports es6-module",</code>
-              <code>  "maintained node versions"</code>
-              <code>]</code>
-            </pre>
-         </a>
-         <h2>Query syntax</h2>
-         <section>
-            <h3>Start with the default configuration</h3>
-            <p>You can pick a sound set of versions with the <a class="QueryLink"><code>defaults</code></a> query which is
-               a shortcut for <code>> 0.5%, last 2 versions, Firefox ESR, not dead</code>.
-               It matches recent versions of popular and supported browsers worldwide and includes
-               Firefox Extended Support Release which is updated roughly annually.
-            </p>
-            <p>The <a class="QueryLink"><code>defaults</code></a> query was thoroughly designed by the
-               Browserslist community.
-               It helps promote best practices and avoid common pitfalls.
-            </p>
-         </section>
+      <section>
+        <h3>Combine multiple queries into one</h3>
+        <p>You can combine versions matched by multiple queries with <code>or</code> or <code>,</code>; you can
+          intersect them with <code>and</code>. You can also negate any query with <code>not</code> if it's
+          not the first one in your list.
+        </p>
+        <h4>Examples</h4>
+        <ul>
+          <li>
+            <a class="QueryLink"><code>> 0.5%, last 2 versions</code></a>
+            combines <a class="QueryLink"><code>> 0.5%</code></a>
+            with <a class="QueryLink"><code>last 2 versions</code></a>.
+          </li>
+          <li><a class="QueryLink"><code>> 0.5% or last 2 versions</code></a>
+            same as above.
+          </li>
+          <li><a class="QueryLink"><code>> 0.5% and last 2 versions</code></a>
+            intersects <a class="QueryLink"><code>> 0.5%</code></a>
+            with <a class="QueryLink"><code>last 2 versions</code></a>.
+          </li>
+          <li><a class="QueryLink"><code>> 0.5% and not last 2 versions</code></a> removes
+            <a class="QueryLink"><code>last 2 versions</code></a> from
+            <a class="QueryLink"><code>> 0.5%</code></a>.
+          </li>
+        </ul>
 
-         <section>
-            <h3>Select browser versions with certain usage</h3>
-            <p>You can pick versions that have more than or less than a certain size of the
-               audience worldwide, in a region, or in a country. You can also use the visitor
-               data of your own website.
-            </p>
-            <h4>Examples</h4>
-            <ul>
-               <li><a class="QueryLink"><code>> 5%</code></a> all versions with > 5% of the audience
-                  worldwide.
-               </li>
-               <li><a class="QueryLink"><code>>= 5% in US</code></a> same as above but in the US.
-               </li>
-               <li><a class="QueryLink"><code>>= 5% in alt-AS</code></a> same as above but in Asia.
-               </li>
-            </ul>
-            <h4>Beware</h4>
-            <ul>
-               <li> You may exclude the most recent versions of all browsers that have been just
-                  released. Please always add <a class="QueryLink" data-query="last 2 versions"><code>last …
-                  versions</code></a> to include them back.
-               </li>
-               <li> You can exclude your global audience. Please be careful when narrowing the audience to a region or a country.
-               </li>
-               <li> You may include <a class="QueryLink"><code>dead</code></a> versions. Please consider
-                  adding <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
-               </li>
-            </ul>
-            
-            <details>
-               <summary>
-                  <h4>Advanced</h4>
-               </summary>
-               <ul>
-                  <li><a class="QueryLink"><code>> 5% in my stats</code></a> versions with >
-                     5%
-                     of usage
-                     within your own audience.
-                  </li>
-                  <li><a class="QueryLink"><code>> 5% in circle-ci stats</code></a>
-                     versions with > 5% of usage within the audience data from shareable configuration, available as <a
-                        href="https://github.com/circleci/circleci-docs/blob/master/browserslist-stats.json" class="Link"
-                        target="_blank">custom stats</a>.
-                  </li>
-                  <li><a class="QueryLink"><code>cover 99.5%</code></a> the smallest set of popular
-                     versions with collective usage over 99.5% of the audience worldwide.
-                  </li>
-                  <li><a class="QueryLink"><code>cover 99.5% in CN</code></a> same as above
-                     but in China.
-                  </li>
-                  <li><a class="QueryLink"><code>cover 99.5% in alt-EU</code></a> same
-                     as above but in Europe.
-                  </li>
-               </ul>
-            </details>
-         </section>
-         
-         <section>
-            <h3>Select recent browser versions</h3>
-            <p>You can pick a few recent browser versions.</p>
-            <h4>Examples</h4>
-            <ul>
-               <li><a class="QueryLink"><code>last 2 versions</code></a> last 2 versions of each
-                  browser.
-               </li>
-               <li><a class="QueryLink"><code>last 2 Chrome versions</code></a> same as above but just
-                  Chrome.
-               </li>
-            </ul>
-            
-            <h4>Beware</h4>
-            <ul>
-               <li>You might exclude older versions still used by a substantial audience.
-                  Please always add <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include them back.
-               </li>
-               <li>You may pick <a class="QueryLink"><code>dead</code></a> browsers like Internet Explorer.
-                  Always use <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
-                  with <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>.
-               </li>
-            </ul>
-            
-            <details>
-               <summary>
-                  <h4>Advanced</h4>
-               </summary>
-               <ul>
-                  <li><a class="QueryLink"><code>last 2 major versions</code></a>
-                     all minor and patch releases of the last 2 major versions.
-                  </li>
-                  <li><a class="QueryLink"><code>last 2 Safari major versions</code></a>
-                     same as above but just Safari.
-                  </li>
-                  <li><a class="QueryLink"><code>unreleased versions</code></a>
-                     alpha and beta versions.
-                  </li>
-                  <li><a class="QueryLink"><code>unreleased Chrome versions</code></a>
-                     same as above but just Chrome.
-                  </li>
-                  <li><a class="QueryLink"><code>since 2020-01-15</code></a>
-                     versions released since Jan 15, 2020.
-                  </li>
-                  <li><a class="QueryLink"><code>since 2020-01</code></a>
-                     versions released since January 2020, inclusive.
-                  </li>
-                  <li><a class="QueryLink"><code>since 2020</code></a>
-                     versions released since 2020, inclusive.
-                  </li>
-                  <li><a class="QueryLink"><code>last 3 years</code></a>
-                     same as above if you run this query in 2022.
-                  </li>
-               </ul>
-            </details>
-         </section>
+        <h4>Beware</h4>
+        <ul>
+          <li> A query with <a class="QueryLink" data-query="defaults, not last 2 versions"><code>not</code></a>
+            can't be the left-hand one in the list.
+          </li>
+          <li> A query with <code>not</code> is always joined to the left-hand one with
+            <a class="QueryLink" data-query="defaults and not last 2 versions"><code>and</code></a>,
+            even if <a class="QueryLink" data-query="defaults or not last 2 versions"><code>or</code></a> or
+            <a class="QueryLink" data-query="defaults, not last 2 versions"><code>,</code></a> are used.
+          </li>
+        </ul>
 
-         <section>
-            <h3>Select specific browser versions</h3>
-            <p>You can pick browser versions or a version range of your choice.</p>
-            <h4>Examples</h4>
-            <ul>
-               <li><a class="QueryLink"><code>ChromeAndroid 103</code></a> mobile Chrome
-                  version 103.
-               </li>
-               <li><a class="QueryLink"><code>Firefox > 20</code></a> desktop Firefox versions
-                  newer than 20.
-               </li>
-               <li><a class="QueryLink"><code>iOS >= 13.2</code></a> mobile Safari version 13.2
-                  and
-                  newer.
-               </li>
-               <li><a class="QueryLink" data-query="defaults, not firefox esr"><code>not Firefox ESR</code></a> removes specific version.
-               </li>
-            </ul>
-            <h4>Beware</h4>
-            <ul>
-               <li> Make sure that your audience uses specific versions (e.g., in a corporate
-                  setting) or that your application is not built to work with specific
-                  versions (e.g., it's a bleeding-edge demo project). Please consider using
-                  <a class="QueryLink" data-query="last 2 versions"><code>last … versions</code></a>
-                  or <a class="QueryLink" data-query="> 5%"><code>> …</code></a> to include more versions.
-               </li>
-               <li>Note, that Opera Mini has special version <code>all</code>. <code>not op_mini all</code> is not a special query.</li>
-            </ul>
+        <details>
+          <summary>
+            <h4>Advanced</h4>
+          </summary>
+          <ul>
+            <li>
+              The following queries yield the same result:
+              <a class="QueryLink"> <code>> 0.5% and not last 2 versions</code></a>,
+              <a class="QueryLink"><code>> 0.5% or not last 2 versions</code></a>,
+              <a class="QueryLink"><code>> 0.5%, not last 2 versions</code></a>.
+            </li>
+          </ul>
+        </details>
+      </section>
 
-            <details>
-               <summary>
-                  <h4>Advanced</h4>
-               </summary>
-               <ul>
-                  <li><a class="QueryLink"><code>ie 6-8</code></a> an inclusive range of Internet
-                     Explorer
-                     versions.
-                  </li>
-                  <li><a class="QueryLink"><code>Firefox ESR</code></a> the latest Firefox Extended
-                     Support Release.
-                  </li>
-               </ul>
-            </details>
-         </section>
+      <section>
+        <h3>Exclude unmaintained browser versions</h3>
+        <p>You can combine your queries with
+          <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>
+          to exclude <a class="QueryLink"><code>dead</code></a> browsers, i.e.,
+          browsers without official support or updates for more than 24 months.
+          Right now these include IE 11, IE Mobile 11, BlackBerry 10, BlackBerry 7,
+          Samsung 4, Opera Mobile 12.1, and all versions of Baidu.
+        </p>
+        <h4>Examples</h4>
+        <ul>
+          <li><a class="QueryLink"><code>> 0.2% and not dead</code></a>
+            excludes <a class="QueryLink"><code>dead</code></a> versions
+            from versions matched by <a class="QueryLink"><code>> 0.2%</code></a>.
+          </li>
+        </ul>
+      </section>
 
-         <section>
-            <h3>Select specific Node.js versions</h3>
-            <p>You can pick Node.js versions or a version range of your choice. Useful if you
-               know for sure the runtime configuration of your server-side code.
-            </p>
-            <h4>Examples</h4>
-            <ul>
-               <li><a class="QueryLink"><code>node 10</code></a> latest
-                  <a class="QueryLink" data-query="node 10.0.0"><code>10.x.x</code></a> Node.js version.
-               </li>
-               <li><a class="QueryLink"><code>node 10.4</code></a> latest
-                  <a class="QueryLink" data-query="node 10.4.0"><code>10.4.x</code></a> Node.js version.
-               </li>
-               <li><a class="QueryLink"><code>node > 16</code></a> all Node.js versions newer than
-                  <code>16.0.0</code>.
-               </li>
-               <li><a class="QueryLink"><code>last 2 node versions</code></a> two latest Node.js releases.
-               </li>
-               <li><a class="QueryLink"><code>last 2 node major versions</code></a> two last major-version Node.js releases.
-               </li>
-            </ul>
+      <h2>Why Browserslist</h2>
+      <p>Browserslist helps you keep the right balance between browser compatibility and bundle size.
+        With Browserslist, you will cover wider audience and have smaller bundle size. 
+      </p>
+    </article>
 
-            <details>
-               <summary>
-                  <h4>Advanced</h4>
-               </summary>
-               <ul>
-                  <li><a class="QueryLink"><code>maintained node versions</code></a>
-                     all Node.js versions currently maintained by Node.js Foundation.
-                  </li>
-                  <li><a class="QueryLink"><code>current node</code></a> the Node.js version used
-                     by Browserslist right now.
-                  </li>
-               </ul>
-            </details>
-         </section>
-
-         <section>
-            <h3>Select browser versions that support a certain feature</h3>
-            <p>You can pick browser versions that fully support features from the Can I Use database. See the
-               <a href="https://github.com/browserslist/caniuse-lite/tree/main/data/features" class="Link" target="_blank">
-               caniuse-lite repository</a> for the full list of features.
-            </p>
-            <h4>Examples</h4>
-            <ul>
-               <li><a class="QueryLink"><code>supports es6-module</code></a> versions that support
-                  JavaScript modules via script tag.
-               </li>
-               <li><a class="QueryLink"><code>supports css-grid</code></a> versions that support CSS Grid Layout.</li>
-            </ul>
-            <h4>Beware</h4>
-            <ul>
-               <li> This query rarely works well on its own. Please consider combining it with other queries.
-               </li>
-            </ul>
-         </section>
-
-         <section>
-            <h3>Combine multiple queries into one</h3>
-            <p>You can combine versions matched by multiple queries with <code>or</code> or <code>,</code>; you can
-               intersect them with <code>and</code>. You can also negate any query with <code>not</code> if it's
-               not the first one in your list.
-            </p>
-            <h4>Examples</h4>
-            <ul>
-               <li>
-                  <a class="QueryLink"><code>> 0.5%, last 2 versions</code></a>
-                  combines <a class="QueryLink"><code>> 0.5%</code></a>
-                  with <a class="QueryLink"><code>last 2 versions</code></a>.
-               </li>
-               <li><a class="QueryLink"><code>> 0.5% or last 2 versions</code></a>
-                  same as above.
-               </li>
-               <li><a class="QueryLink"><code>> 0.5% and last 2 versions</code></a>
-                  intersects <a class="QueryLink"><code>> 0.5%</code></a>
-                  with <a class="QueryLink"><code>last 2 versions</code></a>.
-               </li>
-               <li><a class="QueryLink"><code>> 0.5% and not last 2 versions</code></a> removes
-                  <a class="QueryLink"><code>last 2 versions</code></a> from
-                  <a class="QueryLink"><code>> 0.5%</code></a>.
-               </li>
-            </ul>
-
-            <h4>Beware</h4>
-            <ul>
-               <li> A query with <a class="QueryLink" data-query="defaults, not last 2 versions"><code>not</code></a>
-                  can't be the left-hand one in the list.
-               </li>
-               <li> A query with <code>not</code> is always joined to the left-hand one with
-                  <a class="QueryLink" data-query="defaults and not last 2 versions"><code>and</code></a>,
-                  even if <a class="QueryLink" data-query="defaults or not last 2 versions"><code>or</code></a> or
-                  <a class="QueryLink" data-query="defaults, not last 2 versions"><code>,</code></a> are used.
-               </li>
-            </ul>
-
-            <details>
-               <summary>
-                  <h4>Advanced</h4>
-               </summary>
-               <ul>
-                  <li>
-                     The following queries yield the same result:
-                     <a class="QueryLink"> <code>> 0.5% and not last 2 versions</code></a>,
-                     <a class="QueryLink"><code>> 0.5% or not last 2 versions</code></a>,
-                     <a class="QueryLink"><code>> 0.5%, not last 2 versions</code></a>.
-                  </li>
-               </ul>
-            </details>
-         </section>
-
-         <section>
-            <h3>Exclude unmaintained browser versions</h3>
-            <p>You can combine your queries with
-               <a class="QueryLink" data-query="defaults, not dead"><code>not dead</code></a>
-               to exclude <a class="QueryLink"><code>dead</code></a> browsers, i.e.,
-               browsers without official support or updates for more than 24 months.
-               Right now these include IE 11, IE Mobile 11, BlackBerry 10, BlackBerry 7,
-               Samsung 4, Opera Mobile 12.1, and all versions of Baidu.
-            </p>
-            <h4>Examples</h4>
-            <ul>
-               <li><a class="QueryLink"><code>> 0.2% and not dead</code></a>
-                  excludes <a class="QueryLink"><code>dead</code></a> versions
-                  from versions matched by <a class="QueryLink"><code>> 0.2%</code></a>.
-               </li>
-            </ul>
-         </section>
-
-         <h2>Why Browserslist</h2>
-         <p>Browserslist helps you keep the right balance between browser compatibility and bundle size.
-            With Browserslist, you will cover wider audience and have smaller bundle size. 
-         </p>
-      </article>
-
-      <footer class="Footer">
-         <a class="Badge is-github" href="https://github.com/browserslist/browsersl.ist" target="_blank">
-         <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
-         </a>
-      </footer>
-   </body>
+    <footer class="Footer">
+      <a class="Badge is-github" href="https://github.com/browserslist/browsersl.ist" target="_blank">
+      <img src="./view/Badge/github.svg" alt="" class="Badge_logo"> Website source code
+      </a>
+    </footer>
+  </body>
 </html>


### PR DESCRIPTION
It was ultimately caused by a line-break in the wrong place; it looked like the HTML formatting had decayed a little bit (entirely natural with a manually edited page over a long period of time!) so I ran the whole thing through an autoformatter, which cleaned it up a bit and stripped out some no-break whitespace characters.