### PR TITLE
Add HTML formatting errors handling to QueryLink

### DIFF
--- a/client/view/QueryLink/QueryLink.js
+++ b/client/view/QueryLink/QueryLink.js
@@ -8,9 +8,13 @@ function parse(href) {
   return new URLSearchParams(new URL(href).hash.slice(1))
 }
 
+function formatQuery(text) {
+  return text.trim().replace(/\s+/g, ' ')
+}
+
 for (let link of links) {
   let queryAttr = link.getAttribute('data-query')
-  let query = queryAttr || link.textContent.trim()
+  let query = queryAttr || formatQuery(link.textContent)
 
   link.href = '#' + new URLSearchParams({ q: query })
 


### PR DESCRIPTION
@ialexryan [in this PR](https://github.com/browserslist/browsersl.ist/pull/495) reported a bug with incorrect value substitution in QueryLink's `href`:

 `last 2 Safari major,            versions` instead of `list 2 Safari major versions` 
This error was caused by HTML formatting and automatic replacement of `\n` with `,`.

To fix it, I just removed all duplicate spaces and newline characters, because multiline queries and JSON queries are not supported in the QueryLink component right now (#433)