### PR TITLE
Add a server test to check static file caching

### DIFF
--- a/server/test/cache-static.test.js
+++ b/server/test/cache-static.test.js
@@ -2,10 +2,11 @@ import { ok } from 'node:assert'
 import test from 'node:test'
 import { URL } from 'node:url'
 
-import app from '../index.js'
+process.env.NODE_ENV = 'production'
 
 const PARALLEL_REQUESTS_NUMBER = 100
 
+let app = (await import('../index.js')).default
 let base = `http://localhost:${app.address().port}/`
 
 async function getFetchExecTime(url) {

--- a/server/test/cache-static.test.js
+++ b/server/test/cache-static.test.js
@@ -1,12 +1,13 @@
+import './set-production.js'
+
 import { ok } from 'node:assert'
 import test from 'node:test'
 import { URL } from 'node:url'
 
-process.env.NODE_ENV = 'production'
+import app from '../index.js'
 
 const PARALLEL_REQUESTS_NUMBER = 100
 
-let app = (await import('../index.js')).default
 let base = `http://localhost:${app.address().port}/`
 
 async function getFetchExecTime(url) {

--- a/server/test/cache-static.test.js
+++ b/server/test/cache-static.test.js
@@ -1,0 +1,41 @@
+import { ok } from 'node:assert'
+import test from 'node:test'
+import { URL } from 'node:url'
+
+import app from '../index.js'
+
+const PARALLEL_REQUESTS_NUMBER = 100
+
+let base = `http://localhost:${app.address().port}/`
+
+async function getFetchExecTime(url) {
+  let timeStart = performance.now()
+  await fetch(url)
+  let timeEnd = performance.now()
+  return timeEnd - timeStart
+}
+
+async function getAverageExecTime(url) {
+  let requests = Array(PARALLEL_REQUESTS_NUMBER).fill(getFetchExecTime(url))
+  let totalExecTime = (await Promise.all(requests)).reduce((a, b) => a + b, 0)
+  return totalExecTime / PARALLEL_REQUESTS_NUMBER
+}
+
+test('Cache tests. 100 parallel HTTP-requests are faster than the 1st', async t => {
+  await t.test('favicon `/favicon.ico`', async () => {
+    let url = new URL('/favicon.ico', base)
+    let firstExecTime = await getFetchExecTime(url)
+    let averageExecTime = await getAverageExecTime(url)
+    ok(averageExecTime < firstExecTime)
+  })
+
+  await t.test('main page `/`', async () => {
+    let url = new URL('', base)
+    let firstExecTime = await getFetchExecTime(url)
+    let averageExecTime = await getAverageExecTime(url)
+    ok(averageExecTime < firstExecTime)
+  })
+
+  app.closeAllConnections()
+  app.close()
+})

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -2,9 +2,10 @@ import { equal, match } from 'node:assert'
 import test from 'node:test'
 import { URL } from 'node:url'
 
-import app from '../index.js'
+process.env.NODE_ENV = 'production'
 
-const base = `http://localhost:${app.address().port}/`
+let app = (await import('../index.js')).default
+let base = `http://localhost:${app.address().port}/`
 
 test('Integration tests', async t => {
   await t.test('uses `defaults` query without `q` param', async () => {

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -1,10 +1,11 @@
+import './set-production.js'
+
 import { equal, match } from 'node:assert'
 import test from 'node:test'
 import { URL } from 'node:url'
 
-process.env.NODE_ENV = 'production'
+import app from '../index.js'
 
-let app = (await import('../index.js')).default
 let base = `http://localhost:${app.address().port}/`
 
 test('Integration tests', async t => {

--- a/server/test/set-production.js
+++ b/server/test/set-production.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'production'


### PR DESCRIPTION
Added a server's tests to improve DX — closes #374

- [x] Added a new test to check static file caching
- [x] Now I'm forcibly setting a variable set `NODE_ENV=production` for integration tests. So that the developer does not set environment variables when running tests (like a `NODE_ENV=production pnpm test`)

<img src="https://github.com/browserslist/browsersl.ist/assets/22644149/8ee4d27d-2e4a-48de-b992-af0c8d9503e8" width="500" alt="">


P.S. I'm happy to see the work on the project goes on!