### PR TITLE
Add tests for regions.json prebuild

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,8 +7,9 @@
     "build": "vite build -m production",
     "prebuild": "node ./scripts/build-regions.js",
     "postinstall": "pnpm prebuild",
-    "test:run": "node --test test/*.test.js && size-limit",
-    "test": "pnpm run test:run"
+    "test:run": "node --test test/*.test.js",
+    "test:size": "size-limit",
+    "test": "pnpm run --parallel --filter . /^test:/"
   },
   "dependencies": {
     "@csstools/postcss-oklab-function": "^2.2.3",

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "build": "vite build -m production",
     "prebuild": "node ./scripts/build-regions.js",
     "postinstall": "pnpm prebuild",
-    "test:run": "size-limit",
+    "test:run": "node --test test/*.test.js && size-limit",
     "test": "pnpm run test:run"
   },
   "dependencies": {

--- a/client/scripts/build-regions.js
+++ b/client/scripts/build-regions.js
@@ -17,22 +17,22 @@ function getCaniuseCountries() {
     .sort((a, b) => b - a)
 }
 
-writeFileSync(
-  DATA_REGION_FILE,
-  JSON.stringify({
-    continents: {
-      'alt-af': 'Africa',
-      'alt-an': 'Antarctica',
-      'alt-as': 'Asia',
-      'alt-eu': 'Europe',
-      'alt-na': 'North America',
-      'alt-oc': 'Oceania',
-      'alt-sa': 'South America',
-      'alt-ww': 'Global'
-    },
-    countryCodes: getCaniuseCountries()
-  })
-)
+export const regions = {
+  continents: {
+    'alt-af': 'Africa',
+    'alt-an': 'Antarctica',
+    'alt-as': 'Asia',
+    'alt-eu': 'Europe',
+    'alt-na': 'North America',
+    'alt-oc': 'Oceania',
+    'alt-sa': 'South America',
+    'alt-ww': 'Global'
+  },
+  countryCodes: getCaniuseCountries()
+}
+
+writeFileSync(DATA_REGION_FILE, JSON.stringify(regions))
+
 process.stdout.write(
   `A file "client/${DATA_REGION_FILE}" with regions has been created\n`
 )

--- a/client/test/build-regions.test.js
+++ b/client/test/build-regions.test.js
@@ -1,0 +1,13 @@
+import { ok } from 'node:assert'
+import test from 'node:test'
+
+import { regions } from '../scripts/build-regions.js'
+
+test('Prebuilt `countryCodes` in regions.json contains the 4 most populated countries', () => {
+  let countries = ['CN', 'ID', 'IN', 'US']
+  ok(countries.every(x => regions.countryCodes.includes(x)))
+})
+
+test('Prebuilt `countryCodes` in regions.json not contains `alt-` prefix', () => {
+  ok(regions.countryCodes.every(x => !x.includes('alt-')))
+})


### PR DESCRIPTION
We have a `client/scripts/build-regions.js` that generates a list of countries from caniuse-lite on `postinstall` step.

I added a small tests so that we could notice that something is wrong in the caniuse database.

And, perhaps, the code will become a little clearer for contributors.