### PR TITLE
Add advanced check if config is empty

### DIFF
--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -6,6 +6,7 @@ import { toggleBrowsers, updateBrowsersStats } from '../Browsers/Browsers.js'
 import { toggleHedgehog } from '../Hedgehog/Hedgehog.js'
 import { updateQueryLinksRegion } from '../QueryLink/QueryLink.js'
 import { updateVersions } from '../Versions/Versions.js'
+import { isEmptyConfig } from './isEmptyConfig.js'
 import { loadBrowsers } from './loadBrowsers.js'
 import { transformConfig } from './transformConfig.js'
 
@@ -45,7 +46,7 @@ export function submitForm() {
 
 let prev = ''
 async function updateStatsView(config, region) {
-  if (config.length === 0) {
+  if (isEmptyConfig(config)) {
     formCoverage.hidden = true
     toggleBrowsers(false)
     toggleHedgehog(true)

--- a/client/view/Form/isEmptyConfig.js
+++ b/client/view/Form/isEmptyConfig.js
@@ -1,0 +1,5 @@
+export function isEmptyConfig(config) {
+  let configWithoutComments = config.replace(/#[^\n]*/g, '').trim()
+
+  return configWithoutComments.length === 0
+}


### PR DESCRIPTION
Fixes the case when config consists of comment only.

https://github.com/browserslist/browsersl.ist/assets/35267898/16988ab2-210e-440d-987a-d390bc95cfce

