### PR TITLE
Fix query links

### DIFF
--- a/client/view/QueryLink/QueryLink.js
+++ b/client/view/QueryLink/QueryLink.js
@@ -11,7 +11,8 @@ function parse(href) {
 for (let link of links) {
   let queryAttr = link.getAttribute('data-query')
   // Hack with innerText for not dealing with JSON beautify
-  let config = queryAttr || link.innerText.trim()
+  // but it doesn't work for hidden elements
+  let config = queryAttr || link.innerText.trim() || link.textContent.trim()
 
   link.href = '#' + new URLSearchParams({ q: config })
 


### PR DESCRIPTION
Switching to `innerText` is fine for not dealing with spaces in JSON example. 
But it doesn't work with hidden elements. 