### PR TITLE
Use up-to-date global coverage stats for browser versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ the compatible browsers for a browsers query.
 You can use the site API in your own applications.
 
 ```
-https://browsersl.ist/api/browsers?q=defaults&region=alt-ww
+https://browsersl.ist/api/browsers?q=defaults&region=alt-as
 ```
 
 - `q` — query or config. If config is provided it should be in `.browserslist` file format, not `package.json`-like. Examples are available [on the website](https://browsersl.ist) or in the [browserslist repository](https://github.com/browserslist/browserslist#full-list). `defaults` by default.
-- `region` — region code. List of all region codes can be found at [caniuse-lite/data/regions](https://github.com/browserslist/caniuse-lite/tree/main/data/regions). `alt-ww` by default.
+- `region` — region code (optional). List of all region codes can be found at [caniuse-lite/data/regions](https://github.com/browserslist/caniuse-lite/tree/main/data/regions).
 
 
 ### Response example

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -33,7 +33,7 @@ function createOptgroup(groupName, regionsGroup) {
 export function setFormValues({ config, region }) {
   textarea.value = config
 
-  if (!region) region = 'alt-ww'
+  if (!region) region = DEFAULT_REGION
   let isRegionExists = regionList.includes(region)
   if (region && isRegionExists) {
     regionSelect.value = region

--- a/client/view/Form/loadBrowsers.js
+++ b/client/view/Form/loadBrowsers.js
@@ -1,3 +1,5 @@
+import { DEFAULT_REGION } from '../../data/regions'
+
 let lastRequest = 0
 
 class ServerError extends Error {
@@ -8,13 +10,15 @@ class ServerError extends Error {
 }
 
 export async function loadBrowsers(config, region) {
-  if (!region) region = ''
   lastRequest += 1
   let request = lastRequest
   let response
 
   try {
-    let urlParams = new URLSearchParams({ q: config, region })
+    let urlParams =
+      !region || region === DEFAULT_REGION
+        ? new URLSearchParams({ q: config })
+        : new URLSearchParams({ q: config, region })
     response = await fetch(`/api/browsers?${urlParams}`)
 
     if (request !== lastRequest) {

--- a/server/handlers/api-browsers.js
+++ b/server/handlers/api-browsers.js
@@ -3,7 +3,10 @@ import { sendResponseAPI } from '../lib/send-response.js'
 
 export async function handleAPIBrowsers(req, res, url) {
   let config = url.searchParams.get('q') || 'defaults'
-  let region = url.searchParams.get('region') || 'alt-ww'
+
+  // Specify the default global region as `null`, not `alt-ww`
+  // `caniuse-db` has differences between stats data (https://github.com/Fyrd/caniuse/issues/6811):
+  // `usage_global` in `data.json` is updated daily/weekly, `region-usage-json/alt-ww.json` is updated monthly
   let region = url.searchParams.get('region') || null
 
   try {

--- a/server/handlers/api-browsers.js
+++ b/server/handlers/api-browsers.js
@@ -4,6 +4,8 @@ import { sendResponseAPI } from '../lib/send-response.js'
 export async function handleAPIBrowsers(req, res, url) {
   let config = url.searchParams.get('q') || 'defaults'
   let region = url.searchParams.get('region') || 'alt-ww'
+  let region = url.searchParams.get('region') || null
+
   try {
     sendResponseAPI(res, 200, await getBrowsers(config, region))
   } catch (error) {

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -5,7 +5,11 @@ import { readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath, URL } from 'node:url'
 
-import { getBrowserVersionCoverage, getTotalCoverage } from './get-coverage.js'
+import {
+  getBrowserVersionCoverage,
+  getTotalBrowserCoverage,
+  getTotalCoverage
+} from './get-coverage.js'
 import { configToQuery } from './parse-config.js'
 
 const ROOT = fileURLToPath(import.meta.url)
@@ -57,7 +61,7 @@ export async function getBrowsers(config, region) {
         coverage = null
       } else {
         name = caniuseAgents[id].browser
-        coverage = Object.values(versions).reduce((a, b) => a + b, 0)
+        coverage = getTotalBrowserCoverage(versions)
       }
 
       return {

--- a/server/lib/get-coverage.js
+++ b/server/lib/get-coverage.js
@@ -1,0 +1,46 @@
+import browserslist from 'browserslist'
+import { agents as caniuseAgents, region as caniuseRegion } from 'caniuse-lite'
+
+export function getTotalCoverage(browsers, region) {
+  let isGlobal = !region
+  let coverage = isGlobal
+    ? browserslist.coverage(browsers)
+    : browserslist.coverage(browsers, region)
+
+  // BUG `caniuse-db` returns coverage >100% https://github.com/Fyrd/caniuse/issues/6426
+  coverage = coverage > 100 ? 100 : coverage
+
+  return roundNumber(coverage)
+}
+
+export async function getBrowserVersionCoverage(id, version, region) {
+  let isGlobal = !region
+  if (isGlobal) {
+    return parseBrowserVersionCoverage(caniuseAgents[id].usage_global, version)
+  }
+
+  try {
+    if (region.includes('/')) {
+      throw new Error(`Invalid symbols in region name \`${region}\`.`)
+    }
+
+    let { default: regionData } = await import(
+      `caniuse-lite/data/regions/${region}.js`
+    )
+    return parseBrowserVersionCoverage(caniuseRegion(regionData)[id], version)
+  } catch (e) {
+    throw new Error(`Unknown region name \`${region}\`.`)
+  }
+}
+
+function parseBrowserVersionCoverage(stats, ver) {
+  let [lastVer] = Object.keys(stats).sort((a, b) => Number(b) - Number(a))
+
+  // If specific version coverage is missing, fall back to 'version zero'
+  let coverage = stats[ver] !== undefined ? stats[ver] : stats[lastVer]
+  return roundNumber(coverage)
+}
+
+function roundNumber(value) {
+  return Math.round(value * 100) / 100
+}

--- a/server/lib/get-coverage.js
+++ b/server/lib/get-coverage.js
@@ -20,7 +20,8 @@ export async function getBrowserVersionCoverage(id, version, region) {
   }
 
   try {
-    if (region.includes('/')) {
+    let isValidRegionName = /^(alt-)?[A-Za-z]{2}$/.test(region)
+    if (!isValidRegionName) {
       throw new Error(`Invalid symbols in region name \`${region}\`.`)
     }
 

--- a/server/lib/get-coverage.js
+++ b/server/lib/get-coverage.js
@@ -10,7 +10,12 @@ export function getTotalCoverage(browsers, region) {
   // BUG `caniuse-db` returns coverage >100% https://github.com/Fyrd/caniuse/issues/6426
   coverage = coverage > 100 ? 100 : coverage
 
-  return roundNumber(coverage)
+  return round(coverage)
+}
+
+export function getTotalBrowserCoverage(versions) {
+  let browserVerStats = Object.values(versions)
+  return round(browserVerStats.reduce((sum, x) => sum + x, 0))
 }
 
 export async function getBrowserVersionCoverage(id, version, region) {
@@ -39,9 +44,9 @@ function parseBrowserVersionCoverage(stats, ver) {
 
   // If specific version coverage is missing, fall back to 'version zero'
   let coverage = stats[ver] !== undefined ? stats[ver] : stats[lastVer]
-  return roundNumber(coverage)
+  return round(coverage)
 }
 
-function roundNumber(value) {
+function round(value) {
   return Math.round(value * 100) / 100
 }

--- a/server/test/browsers.test.js
+++ b/server/test/browsers.test.js
@@ -3,6 +3,12 @@ import test from 'node:test'
 
 import { getBrowsers } from '../lib/get-browsers.js'
 
+function approximatelyEqual(actual, expected) {
+  let tolerance = 2
+  let diff = Math.abs(actual - expected)
+  ok(diff <= tolerance)
+}
+
 test('Throws error for wrong browserslist `query`', async () => {
   let error
   try {
@@ -46,4 +52,20 @@ test('Coverage of all browsers should differ in regions', async () => {
   let countryData = await getBrowsers('>1%', 'IT')
 
   notEqual(continentData.coverage, countryData.coverage)
+})
+
+test('The sum of the coverage versions equals the total coverage in global', async () => {
+  let data = await getBrowsers('cover 80%')
+  let sumOfCoverages = data.browsers.reduce((sum, x) => sum + x.coverage, 0)
+  let totalCoverage = data.coverage
+
+  approximatelyEqual(sumOfCoverages, totalCoverage)
+})
+
+test('The sum of the coverage versions equals the total coverage in region', async () => {
+  let data = await getBrowsers('cover 45% in BR', 'BR')
+  let sumOfCoverages = data.browsers.reduce((sum, x) => sum + x.coverage, 0)
+  let totalCoverage = data.coverage
+
+  approximatelyEqual(sumOfCoverages, totalCoverage)
 })

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -20,7 +20,7 @@ test('Integration tests', async t => {
     let url = new URL(`api/browsers`, base)
     let response = await fetch(url)
     let data = await response.json()
-    equal(data.region, 'alt-ww')
+    equal(data.region, null)
   })
 
   await t.test('responses status 200 for `/browsers` route', async () => {


### PR DESCRIPTION
I saw issues by @MonstraG (#512 & https://github.com/Fyrd/caniuse/issues/6811) about errors in browser usage statistics. 

## TL;DR
Now we will use stats that is updated dayly/weekly, not once a month (how it is implemented in the `browserlist.coverage()`)

### Before
![image](https://github.com/browserslist/browsersl.ist/assets/22644149/69f98dde-6c59-4cf1-b278-3a810664a0cf)

### After
![image](https://github.com/browserslist/browsersl.ist/assets/22644149/4048b138-747f-444d-964c-46e408620f05)

## Problem
![image](https://github.com/browserslist/browsersl.ist/assets/22644149/5cc35b6c-ffd5-47d6-a943-4589ab94fda7)

- Site show stats from **[region-usage-json/alt-ww.json](https://github.com/Fyrd/caniuse/blob/main/region-usage-json/alt-ww.json)**  — updated **monthly**
- `browserslist.coverage()` use global stats from **[data.json](https://github.com/Fyrd/caniuse/blob/main/data.json)** — updated **daily/weekly**


## Changes
- [x] Use `usage_global` instead `alt-ww`
- [x] API returns `region: null` instead `alt-ww` by default
- [x] Add tests for `coverage` queries
- [x] Update API example in README.md
- [x] Improve readability (module `get-coverage.js`)
