### PR TITLE
Not send `?region` param if region `alt-ww`

### DIFF
--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -33,7 +33,7 @@ function createOptgroup(groupName, regionsGroup) {
 export function setFormValues({ config, region }) {
   textarea.value = config
 
-  if (!region) region = 'alt-ww'
+  if (!region) region = DEFAULT_REGION
   let isRegionExists = regionList.includes(region)
   if (region && isRegionExists) {
     regionSelect.value = region

--- a/client/view/Form/loadBrowsers.js
+++ b/client/view/Form/loadBrowsers.js
@@ -1,3 +1,5 @@
+import { DEFAULT_REGION } from '../../data/regions'
+
 let lastRequest = 0
 
 class ServerError extends Error {
@@ -8,13 +10,15 @@ class ServerError extends Error {
 }
 
 export async function loadBrowsers(config, region) {
-  if (!region) region = ''
   lastRequest += 1
   let request = lastRequest
   let response
 
   try {
-    let urlParams = new URLSearchParams({ q: config, region })
+    let urlParams =
+      !region || region === DEFAULT_REGION
+        ? new URLSearchParams({ q: config })
+        : new URLSearchParams({ q: config, region })
     response = await fetch(`/api/browsers?${urlParams}`)
 
     if (request !== lastRequest) {


### PR DESCRIPTION
Now we won't substitute region if it's not global (unfortunately we can't trust `alt-ww`)

<img width="1102" alt="image" src="https://github.com/browserslist/browsersl.ist/assets/22644149/76b79ea7-206f-418d-9cce-49bdca3ea9b2">