### PR TITLE
Send browseslist queries to Plausible

### DIFF
--- a/client/view/Alert/Alert.js
+++ b/client/view/Alert/Alert.js
@@ -29,7 +29,7 @@ export function buildWarning(root, message, fixed) {
   warning.appendChild(fix)
   root.appendChild(warning)
   link.addEventListener('click', () => {
-    trackEvent('Fix query')
+    trackEvent('Fix query', { props: { query: fixed } })
   })
   return { fix, warning }
 }

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -17,6 +17,14 @@ let textarea = document.querySelector('[data-id=form_textarea]')
 let regionSelect = document.querySelector('[data-id=form_region]')
 let messages = document.querySelector('[data-id=form_messages]')
 
+function getUrlParams() {
+  let urlParams = new URLSearchParams(location.hash.slice(1))
+  return {
+    config: urlParams.get('q'),
+    region: urlParams.get('region')
+  }
+}
+
 function createOptgroup(groupName, regionsGroup) {
   let optgroup = createTag('optgroup')
   optgroup.label = groupName
@@ -103,12 +111,7 @@ function changeUrl(config, region) {
 }
 
 function submitFormWithUrlParams() {
-  let urlParams = new URLSearchParams(location.hash.slice(1))
-
-  let config = urlParams.get('q')
-  let region = urlParams.get('region')
-
-  setFormValues({ config, region })
+  setFormValues(getUrlParams())
   submitForm()
 }
 
@@ -169,7 +172,11 @@ textarea.addEventListener('input', () => {
   submitFormDebounced()
 })
 
-submitFormWithUrlParams()
+if (getUrlParams().config) {
+  trackEvent('Open query', { props: getUrlParams() })
+  submitFormWithUrlParams()
+}
+
 window.addEventListener('hashchange', () => {
   submitFormWithUrlParams()
 })

--- a/client/view/Form/Form.js
+++ b/client/view/Form/Form.js
@@ -17,6 +17,14 @@ let textarea = document.querySelector('[data-id=form_textarea]')
 let regionSelect = document.querySelector('[data-id=form_region]')
 let messages = document.querySelector('[data-id=form_messages]')
 
+function getFormData() {
+  let formData = new FormData(form)
+  return {
+    config: formData.get('config'),
+    region: formData.get('region')
+  }
+}
+
 function getUrlParams() {
   let urlParams = new URLSearchParams(location.hash.slice(1))
   return {
@@ -156,21 +164,20 @@ regionSelect.addEventListener('change', () => {
 
 form.addEventListener('submit', e => {
   e.preventDefault()
-
-  let formData = new FormData(form)
-  let config = formData.get('config')
-  let region = formData.get('region')
+  let { config, region } = getFormData()
 
   changeUrl(config, region)
   updateStatsView(config, region)
   updateQueryLinksRegion(region)
 })
 
-let submitFormDebounced = debounce(submitForm, 300)
+let handleInputDebounced = debounce(() => {
+  let { config } = getFormData()
+  trackEvent('Enter query', { props: { query: config } })
+  submitForm()
+}, 300)
 
-textarea.addEventListener('input', () => {
-  submitFormDebounced()
-})
+textarea.addEventListener('input', () => handleInputDebounced())
 
 if (getUrlParams().config) {
   trackEvent('Open query', { props: getUrlParams() })

--- a/client/view/QueryLink/QueryLink.js
+++ b/client/view/QueryLink/QueryLink.js
@@ -1,4 +1,5 @@
 import { DEFAULT_REGION } from '../../data/regions.js'
+import { trackEvent } from '../../lib/analytics.js'
 import { setFormValues, submitForm } from '../Form/Form.js'
 import { scrollToInteractive } from '../Interactive/Interactive.js'
 
@@ -20,6 +21,7 @@ for (let link of links) {
     e.preventDefault()
     let region = parse(link.href).get('region')
 
+    trackEvent('Click on query', { props: { query: config } })
     setFormValues({ config, region })
     submitForm()
     scrollToInteractive()


### PR DESCRIPTION
Now we can send browserslist queries to Plausible. And we can better understand the purpose of these queries to analyze the needs of our users. 

## Add new events
- [x] Open query (props: `query`, `region`)
- [x] Click on query (props: `query`)
- [x] Enter query (props: `query`)

## Update event
- [x] Fix query — add prop `query`


## Additionaly
- [x] Add reusable functions  `getFormData()` & `getUrlParams()`
- [x] Not send form `'submit'` event on page start if `q` not exist


<details>
    <summary>Prev outdated PR description</summary>

- [x] Remove `Change region` event
- [x] Combine the `query` and `region` parameters into the `Send query` event

## Alternative way
In this PR I made a simple version, but we can send more events and see them in filters.

This will help us analyze the goal of sending a query by our users.


UPD
```js
trackEvent('Change region', { props: { region } }) // not remove

trackEvent('Open query', { props: { query } })
trackEvent('Fix query', { props: { query } }) // add "query" prop to "Fix query"
trackEvent('Enter query', { props: { query } })
trackEvent('Click on query', { props: { query } })
```


</details>
