### PR TITLE
README: use correct query string in HTTP API response example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://browsersl.ist/api/browsers?q=defaults&region=alt-as
 ### Response example
 
 ```js
-// https://browsersl.ist/api/browsers?q=>defaults+and+supports+es6-module&region=alt-as
+// https://browsersl.ist/api/browsers?q=defaults+and+supports+es6-module&region=alt-as
 
 {
   "config": ">0.3%",


### PR DESCRIPTION
This PR removes the leading `>` operator from the example query string: `>defaults` is not [valid query syntax](https://github.com/browserslist/browserslist?tab=readme-ov-file#queries).