### PR TITLE
Remove `X-Frame-Options` protection from HEADER

### DIFF
--- a/server/handlers/main.js
+++ b/server/handlers/main.js
@@ -11,7 +11,6 @@ const HEADERS = {
     `script-src 'self'`,
   'Content-Type': 'text/html; charset=utf-8',
   'X-Content-Type-Options': 'nosniff',
-  'X-Frame-Options': 'DENY',
   'X-XSS-Protection': '1; mode=block'
 }
 const INDEX = new URL('../../client/dist/index.html', import.meta.url)


### PR DESCRIPTION
Sorry I did not see that there also was an `X-Frame-Options` header

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options