### PR TITLE
New deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/new-deploy'
     needs:
       - test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs:
       - test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
     branches:
       - main
   pull_request:
-permissions:
-  contents: read
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -28,6 +28,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     # if: github.ref == 'refs/heads/main'
     needs:
       - test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/new-deploy'
+    # if: github.ref == 'refs/heads/main'
     needs:
       - test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,45 @@ jobs:
         run: pnpm prebuild
       - name: Build static files
         run: pnpm build
+      - name: Build Docker image
+        shell: bash
+        run: docker build -t us-east1-docker.pkg.dev/browserslist-359212/production/server:latest ./
       - name: Auth Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+          workload_identity_provider: projects/599133183470/locations/global/workloadIdentityPools/github/providers/browserslist
+          service_account: github-deploy@browserslist-359212.iam.gserviceaccount.com
       - name: Install Google Cloud
-        uses: google-github-actions/setup-gcloud@v1
-      - name: Deploy files
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Auth Docker
+        shell: bash
+        run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
+      - name: Push Docker image
+        shell: bash
+        run: docker push us-east1-docker.pkg.dev/browserslist-359212/production/server:latest
+      - name: Deploy to Cloud Run
         id: deploy
-        run: ./node_modules/.bin/ssdeploy deploy --verbose
-        env:
-          GCLOUD_APP: ${{ secrets.GCLOUD_APP }}
-          GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
-          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+        uses: google-github-actions/deploy-cloudrun@v2.7.3
+        with:
+          service: browserslist
+          region: us-east1
+          image: us-east1-docker.pkg.dev/browserslist-359212/production/server:latest
+          flags: |
+            --allow-unauthenticated
+            --service-account=github-deploy@browserslist-359212.iam.gserviceaccount.com
+      - name: Move traffic to new revision
+        shell: bash
+        run: |
+          gcloud run services update-traffic browserslist \
+            --project browserslist-359212 \
+            --region us-east1 \
+            --to-latest
+      - name: Delete previous images
+        shell: bash
+        run: |
+          untagged=$(gcloud artifacts docker images list us-east1-docker.pkg.dev/browserslist-359212/production/server --include-tags --format="get(version)" --filter="NOT tags:*")
+          for digest in $untagged; do
+            image=us-east1-docker.pkg.dev/browserslist-359212/production/server@$digest
+            echo "Deleting unused image: $image"
+            gcloud artifacts docker images delete $image --quiet
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,12 @@ RUN strip /usr/local/bin/node
 WORKDIR /var/app
 COPY . /var/app/
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts -F server
-RUN ls node_modules/
 
 FROM cgr.dev/chainguard/glibc-dynamic:latest
 WORKDIR /var/app
 ENV NODE_ENV production
 
 COPY --from=base /usr/local/bin/node /usr/local/bin/node
-COPY ./pnpm-workspace.yaml /var/app/
 COPY ./package.json /var/app/
 COPY ./pnpm-lock.yaml /var/app/
 COPY ./lib/ /var/app/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,36 @@
-FROM node:22.14.0-alpine
+FROM cgr.dev/chainguard/wolfi-base:latest as base
 
+ENV NODE_VERSION 22.14.0
+ENV PNPM_VERSION 10.7.1
+
+ADD https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz /node.tar.xz
+RUN tar -xf "node.tar.xz" --strip-components=1 -C /usr/local/ \
+    "node-v${NODE_VERSION}-linux-x64/bin/node"
+ADD https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linux-x64 /usr/local/bin/pnpm
+RUN chmod a+rx /usr/local/bin/pnpm
+RUN apk add --no-cache binutils
+RUN strip /usr/local/bin/node
+
+WORKDIR /var/app
+COPY . /var/app/
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts -F server
+RUN ls node_modules/
+
+FROM cgr.dev/chainguard/glibc-dynamic:latest
+WORKDIR /var/app
 ENV NODE_ENV production
-WORKDIR /var/www
-COPY --chown=node:node . /var/www
 
-RUN corepack enable
-RUN corepack prepare pnpm@10.5.1 --activate
-COPY ./pnpm-workspace.yaml /var/www/
-COPY ./package.json /var/www/
-COPY ./pnpm-lock.yaml /var/www/
-COPY ./server/ /var/www/server/
-RUN pnpm install --filter ./server --prod --frozen-lockfile --ignore-scripts
-COPY ./client/dist/ /var/www/client/dist/
+COPY --from=base /usr/local/bin/node /usr/local/bin/node
+COPY ./pnpm-workspace.yaml /var/app/
+COPY ./package.json /var/app/
+COPY ./pnpm-lock.yaml /var/app/
+COPY ./lib/ /var/app/lib/
+COPY ./server/ /var/app/server/
+COPY ./client/dist/ /var/app/client/dist/
+COPY --from=base /var/app/node_modules/ /var/app/node_modules/
 
-CMD "node" "server/index.js"
+USER nonroot
+
+ENTRYPOINT ["/usr/local/bin/node"]
+CMD ["server/index.js"]
+

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "browserl.ist-client",
+  "name": "client",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "test:audit": "pnpm audit --prod",
     "test": "pnpm run prebuild && pnpm build && pnpm run --recursive --include-workspace-root /^test:/"
   },
-  "dependencies": {
-    "ssdeploy": "^0.9.3"
-  },
   "devDependencies": {
     "@logux/eslint-config": "^55.0.1",
     "@logux/stylelint-config": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.5.1",
+  "packageManager": "pnpm@10.7.1",
   "scripts": {
     "start": "pnpm -r start",
     "prebuild": "pnpm -r prebuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      ssdeploy:
-        specifier: ^0.9.3
-        version: 0.9.3
     devDependencies:
       '@logux/eslint-config':
         specifier: ^55.0.1
@@ -694,10 +690,6 @@ packages:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
     engines: {node: '>= 0.8'}
 
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
   cacheable@1.8.9:
     resolution: {integrity: sha512-FicwAUyWnrtnd4QqYAoRlNs44/a1jTL7XDKqm5gJ90wz1DQPlC7U2Rd1Tydpv+E7WAr4sQHuw8Q8M3nZMAyecQ==}
 
@@ -815,10 +807,6 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  define-lazy-prop@2.0.0:
-    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
-    engines: {node: '>=8'}
-
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -842,10 +830,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@16.4.7:
-    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1042,11 +1026,6 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  folder-hash@4.1.1:
-    resolution: {integrity: sha512-1ZSlKJSbET3XpglnEXC9g+QF4QRZhqHIjpFfa4pAMfO4tu/XYPafpeHEX6zOFS2EolOIXr0lPh1eSjmdWItX2w==}
-    engines: {node: '>=10.10.0'}
-    hasBin: true
-
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -1126,10 +1105,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasha@5.2.2:
-    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
-    engines: {node: '>=8'}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -1170,11 +1145,6 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
-  is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-
   is-expression@4.0.0:
     resolution: {integrity: sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==}
 
@@ -1204,14 +1174,6 @@ packages:
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-
-  is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1327,10 +1289,6 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@7.4.6:
-    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
-    engines: {node: '>=10'}
-
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1375,10 +1333,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  open@8.4.2:
-    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
-    engines: {node: '>=12'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1606,11 +1560,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  ssdeploy@0.9.3:
-    resolution: {integrity: sha512-bQTsCp3HMpSmTtoqoaJCmIOvl9iYmARo4D+bKYNLhhN+dQCtvVHV0GoGltNiWy/OtSjIv0q1uNEkrPx5Qi3jnA==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-
   stable-hash@0.0.4:
     resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
 
@@ -1710,10 +1659,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-fest@0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
-    engines: {node: '>=8'}
 
   typescript-eslint@8.26.1:
     resolution: {integrity: sha512-t/oIs9mYyrwZGRpDv3g+3K6nZ5uhKEMt2oNmAPwaY4/ye0+EH4nXIPYNtkYFS6QHm+1DFg34DbglYBz5P9Xysg==}
@@ -2305,8 +2250,6 @@ snapshots:
 
   bytes-iec@3.1.1: {}
 
-  bytes@3.1.2: {}
-
   cacheable@1.8.9:
     dependencies:
       hookified: 1.7.1
@@ -2416,8 +2359,6 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  define-lazy-prop@2.0.0: {}
-
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -2445,8 +2386,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dotenv@16.4.7: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2709,13 +2648,6 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  folder-hash@4.1.1:
-    dependencies:
-      debug: 4.4.0
-      minimatch: 7.4.6
-    transitivePeerDependencies:
-      - supports-color
-
   fraction.js@4.3.7: {}
 
   fsevents@2.3.3:
@@ -2794,11 +2726,6 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasha@5.2.2:
-    dependencies:
-      is-stream: 2.0.1
-      type-fest: 0.8.1
-
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -2828,8 +2755,6 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
-  is-docker@2.2.1: {}
-
   is-expression@4.0.0:
     dependencies:
       acorn: 7.4.1
@@ -2855,12 +2780,6 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  is-stream@2.0.1: {}
-
-  is-wsl@2.2.0:
-    dependencies:
-      is-docker: 2.2.1
 
   isexe@2.0.0: {}
 
@@ -2959,10 +2878,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
-  minimatch@7.4.6:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -2994,12 +2909,6 @@ snapshots:
       boolbase: 1.0.0
 
   object-assign@4.1.1: {}
-
-  open@8.4.2:
-    dependencies:
-      define-lazy-prop: 2.0.0
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -3244,17 +3153,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  ssdeploy@0.9.3:
-    dependencies:
-      bytes: 3.1.2
-      dotenv: 16.4.7
-      folder-hash: 4.1.1
-      hasha: 5.2.2
-      open: 8.4.2
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   stable-hash@0.0.4: {}
 
   string-width@4.2.3:
@@ -3391,8 +3289,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-fest@0.8.1: {}
 
   typescript-eslint@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.6.2):
     dependencies:

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -10,14 +10,14 @@ let packageJson = readFileSync(join(ROOT, 'package.json')).toString()
 let pnpmVersion = packageJson.match(/pnpm@([.\d]+)/)[1]
 let nodeMajor = nodeVersion.match(/^(\d+)\./)[1]
 
-if (!dockerfile.includes(` pnpm@${pnpmVersion} `)) {
+if (!dockerfile.includes(`PNPM_VERSION ${pnpmVersion}`)) {
   process.stderr.write(
     'Dockerfile and package.json have different pnpm version\n'
   )
   process.exit(1)
 }
 
-if (!dockerfile.includes(`FROM node:${nodeVersion}-alpine`)) {
+if (!dockerfile.includes(`NODE_VERSION ${nodeVersion}`)) {
   process.stderr.write(
     'Dockerfile and .node-version have different node version\n'
   )

--- a/scripts/run-image.sh
+++ b/scripts/run-image.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+ERROR='\033[0;31m'
+WARNING='\033[0;33m'
+NC='\033[0m' # No Color
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+run_container() {
+  local container_tool=$1
+  local port=$2
+  local image_id=$3
+
+  $container_tool run --rm -p "$port:$port" -e PORT=$port -it "$image_id"
+}
+
+build_and_run() {
+  local port=$1
+
+  # Select container tool (podman or docker)
+  local tool
+  if command_exists podman; then
+    tool="podman"
+  elif command_exists docker; then
+    tool="docker"
+  else
+    echo -e "${ERROR}Install Podman or Docker${NC}"
+    exit 1
+  fi
+
+  echo "Building image with $tool"
+  BUILD_OUTPUT=$($tool build . 2>&1) || {
+    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
+    exit 1
+  }
+  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
+
+  SIZE=$($tool image inspect "$IMAGE_ID" --format='{{.Size}}' | \
+    awk '{printf "%d MB", $1/1024/1024}')
+  echo -e "${WARNING}Image size: ${SIZE}${NC}"
+  echo "Open: http://localhost:$port"
+
+  run_container "$tool" "$port" "$IMAGE_ID"
+}
+
+build_and_run 8080

--- a/server/index.js
+++ b/server/index.js
@@ -38,6 +38,12 @@ app.listen(PORT, () => {
   }
 })
 
+process.on('SIGINT', () => {
+  app.close(() => {
+    process.exit(0)
+  })
+})
+
 export { PORT }
 
 export default app

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "browserl.ist-server",
+  "name": "server",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- [x] Move to Google Artifact Registry because Google Cloud Registry was deprecated.
- [x] Remove semi-deprecated `ssdeploy` by extracting scripts
- [x] Reduce Docker image by new practices (**183 → 111 MB**)
  - [x] chainguard base images
  - [x] Manually node and pnpm download without unnecessary tools
  - [x] Multi-stage build to avoid pnpm in final image
  - [x] Filtering project’s dependencies by pnpm `-F`