### PR TITLE
Fix opencollective link

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -27,7 +27,7 @@
       <a class="Badge is-github" href="https://github.com/browserslist/browserslist" target="_blank">
         <img src="./view/Badge/github.svg" alt="Count of GitHub stars" class="Badge_logo"> 13K
       </a>
-      <a class="Badge is-secondary" href="opencollective.com/browserslist"  target="_blank">
+      <a class="Badge is-secondary" href="https://opencollective.com/browserslist"  target="_blank">
         <img src="./view/Badge/opencollective.svg" alt="" class="Badge_logo"> Open Collective
       </a>
       <a class="Badge is-secondary" href="https://twitter.com/Browserslist"  target="_blank">


### PR DESCRIPTION
Add missed `https` in opencollective.com link