### PR TITLE
chore: fix github sponsors link

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -34,7 +34,7 @@
         <a class="Badges_item is-secondary" href="https://opencollective.com/browserslist" target="_blank">
           <img src="./view/Badges/opencollective.svg" alt="" class="Badges_item_logo"> Open Collective
         </a>
-        <a class="Badges_item is-secondary" href="https://twitter.com/Browserslist"  target="_blank">
+        <a class="Badges_item is-secondary" href="https://github.com/sponsors/ai"  target="_blank">
           <img src="./view/Badges/ghsponsors.svg" alt="" class="Badges_item_logo"> GitHub Sponsors
         </a>
       </div>


### PR DESCRIPTION
Not much to it! But the GitHub Sponsors button is presumably meant to link to your GitHub Sponsors, not to Twitter. ^-^'
